### PR TITLE
Add Bayesian revenue impact overlay to sequential analysis page

### DIFF
--- a/pages/sequential_analysis.py
+++ b/pages/sequential_analysis.py
@@ -3,6 +3,7 @@ import altair as alt
 import pandas as pd
 import numpy as np
 import uuid
+from dataclasses import dataclass
 from scipy.stats import norm as scipy_norm
 from st_supabase_connection import SupabaseConnection
 
@@ -107,6 +108,108 @@ def calculate_instantaneous_power(n_var, p0, mde, alpha, n_ctrl=None):
     z_power = mde / se - z_alpha
     power = float(scipy_norm.cdf(z_power))
     return power, 1.0 - power
+
+
+# --- BUSINESS IMPACT (BAYESIAN REVENUE OVERLAY) ---
+# Ad-hoc monetary lens on top of the locked mSPRT test, mirroring the Bayesian
+# business-case simulation in experiment_analysis.py (Beta posterior CR +
+# log-normal AOV + lift-plausibility weighting). It never feeds back into
+# alpha/beta/tau or the LLR decision itself.
+
+@dataclass(frozen=True)
+class LiftPrior:
+    mean_log_lift: float
+    std_log_lift: float
+
+
+_LIFT_PRIOR_STD = {
+    "skeptical": 0.10,
+    "moderate": 0.25,
+    "uninformative": 1.00,
+}
+
+BUSINESS_PROJECTION_DAYS = 183  # ~6 months, matches the Business Case page
+
+
+def get_lift_prior(expected_lift_pct, skepticism):
+    if expected_lift_pct <= -100:
+        raise ValueError("expected_lift_pct must be greater than -100.")
+    return LiftPrior(
+        mean_log_lift=np.log1p(expected_lift_pct / 100.0),
+        std_log_lift=_LIFT_PRIOR_STD[skepticism],
+    )
+
+
+def compute_lift_weights(cr_samples_control, cr_samples_challenger, prior):
+    log_lift = np.log(cr_samples_challenger) - np.log(cr_samples_control)
+    log_w = scipy_norm.logpdf(log_lift, prior.mean_log_lift, prior.std_log_lift)
+    w = np.exp(log_w - log_w.max())
+    return w / w.sum()
+
+
+def sample_aov(mean_aov, cv, n_samples, rng):
+    if mean_aov <= 0:
+        return np.zeros(n_samples)
+    sigma2 = np.log1p(cv ** 2)
+    mu = np.log(mean_aov) - sigma2 / 2
+    return rng.lognormal(mean=mu, sigma=np.sqrt(sigma2), size=n_samples)
+
+
+def estimate_revenue_impact(
+    control_visitors, control_conversions,
+    variant_visitors, variant_conversions,
+    aov, aov_cv, days_elapsed, lift_prior,
+    fixed_control_cr=None,
+    n_simulations=20000, seed=42,
+):
+    """
+    Bayesian monetary overlay on the current cumulative counts.
+
+    One-sample tests have no measured control traffic, so the baseline is
+    treated as a fixed rate (fixed_control_cr) rather than a posterior --
+    consistent with how the LLR itself treats p0.
+    """
+    rng = np.random.default_rng(seed)
+
+    if fixed_control_cr is not None:
+        control_cr = np.full(n_simulations, fixed_control_cr)
+        control_daily_conv = control_cr * (variant_visitors / days_elapsed)
+    else:
+        control_cr = rng.beta(
+            1 + control_conversions, 1 + (control_visitors - control_conversions), size=n_simulations
+        )
+        control_daily_conv = control_cr * (control_visitors / days_elapsed)
+
+    variant_cr = rng.beta(
+        1 + variant_conversions, 1 + (variant_visitors - variant_conversions), size=n_simulations
+    )
+    variant_daily_conv = variant_cr * (variant_visitors / days_elapsed)
+
+    weights = compute_lift_weights(control_cr, variant_cr, lift_prior)
+    aov_samples = sample_aov(aov, aov_cv, n_simulations, rng)
+
+    diff = variant_daily_conv - control_daily_conv
+    positive_mask = diff > 0
+    negative_mask = diff < 0
+
+    prob_variant_better = np.average(positive_mask, weights=weights)
+    prob_control_better = np.average(negative_mask, weights=weights)
+
+    expected_daily_gain = (
+        np.average(diff * aov_samples, weights=weights * positive_mask)
+        if positive_mask.any() else 0.0
+    )
+    expected_daily_loss = (
+        np.average(diff * aov_samples, weights=weights * negative_mask)
+        if negative_mask.any() else 0.0
+    )
+
+    return {
+        "prob_variant_better": float(prob_variant_better),
+        "prob_control_better": float(prob_control_better),
+        "expected_daily_gain": float(expected_daily_gain),
+        "expected_daily_loss": float(expected_daily_loss),
+    }
 
 
 # --- DATABASE FUNCTIONS ---
@@ -345,6 +448,55 @@ def analysis_section(df, params):
     power_data = []
     mde = np.sqrt(tau_param)
 
+    # --- BUSINESS IMPACT SETTINGS (ad-hoc, does not affect the locked test) ---
+    with st.expander("💰 Revenue Impact Settings (optional)", expanded=False):
+        st.caption(
+            "Ad-hoc monetary overlay on top of the locked mSPRT test. Entering an AOV "
+            "translates the current evidence into an estimated revenue impact — it never "
+            "changes alpha/beta/tau or the LLR decision itself."
+        )
+        aov_value = st.number_input(
+            "Average Order Value (€)",
+            min_value=0.0, step=0.01,
+            value=st.session_state.get("seq_aov", 0.0),
+            key="seq_aov",
+            help="Leave at 0 to hide the revenue impact section.",
+        )
+        aov_cv = st.slider(
+            "AOV Variability",
+            min_value=0.1, max_value=2.0, step=0.1,
+            value=st.session_state.get("seq_aov_cv", 0.5),
+            key="seq_aov_cv",
+            help="Coefficient of variation for order value (std / mean). Does not affect "
+                 "the average prediction, only the spread.",
+        )
+
+        use_lift_prior = st.checkbox(
+            "Apply a lift prior?",
+            value=st.session_state.get("seq_use_lift_prior", False),
+            key="seq_use_lift_prior",
+            help="Express skepticism about large lifts before seeing the data.",
+        )
+        if use_lift_prior:
+            lp_col1, lp_col2 = st.columns(2)
+            expected_lift_pct = lp_col1.number_input(
+                "Expected Lift (%)", min_value=-99.0, max_value=1000.0, step=0.1,
+                value=st.session_state.get("seq_expected_lift_pct", 0.0),
+                key="seq_expected_lift_pct",
+            )
+            skepticism = lp_col2.selectbox(
+                "Skepticism", ["skeptical", "moderate", "uninformative"],
+                index=["skeptical", "moderate", "uninformative"].index(
+                    st.session_state.get("seq_skepticism", "skeptical")
+                ),
+                key="seq_skepticism",
+            )
+            lift_prior = get_lift_prior(expected_lift_pct=expected_lift_pct, skepticism=skepticism)
+        else:
+            lift_prior = get_lift_prior(expected_lift_pct=0.0, skepticism="uninformative")
+
+    revenue_enabled = aov_value > 0
+
     for variant in variants_to_test:
         var_df = df[df["variant_name"] == variant].copy()
         # Guard against duplicate dates
@@ -506,13 +658,14 @@ def analysis_section(df, params):
             st.progress(progress / 100)
 
             # --- TIME ESTIMATION ---
+            first_date = merged["measurement_date"].min()
+            last_date = merged["measurement_date"].max()
+            days_elapsed = max((last_date - first_date).days, 1)
+            est_days = None
+
             if latest_llr > 0 and not (
                 latest_llr > upper_bound or latest_llr < lower_bound
             ):
-                first_date = merged["measurement_date"].min()
-                last_date = merged["measurement_date"].max()
-                days_elapsed = max((last_date - first_date).days, 1)
-
                 avg_daily_visitors = latest_vis / days_elapsed
                 llr_per_vis = latest_llr / latest_vis
                 remaining_llr = upper_bound - latest_llr
@@ -554,6 +707,60 @@ def analysis_section(df, params):
                     st.warning("Maximum sample size reached without a decision.")
                 else:
                     st.info("INCONCLUSIVE - Continue collecting data.")
+
+            # --- REVENUE IMPACT (Bayesian overlay) ---
+            if revenue_enabled:
+                st.divider()
+                st.markdown("##### 💰 Revenue Impact")
+
+                if test_type == TEST_TYPE_MULTI_SAMPLE:
+                    impact = estimate_revenue_impact(
+                        control_visitors=base_vis,
+                        control_conversions=merged.iloc[-1]["conversions_ctrl"],
+                        variant_visitors=latest_vis,
+                        variant_conversions=latest_conv,
+                        aov=aov_value, aov_cv=aov_cv,
+                        days_elapsed=days_elapsed, lift_prior=lift_prior,
+                    )
+                else:
+                    impact = estimate_revenue_impact(
+                        control_visitors=None, control_conversions=None,
+                        variant_visitors=latest_vis, variant_conversions=latest_conv,
+                        aov=aov_value, aov_cv=aov_cv,
+                        days_elapsed=days_elapsed, lift_prior=lift_prior,
+                        fixed_control_cr=base_cr,
+                    )
+
+                stop_now_uplift = (
+                    impact["expected_daily_gain"] * BUSINESS_PROJECTION_DAYS * impact["prob_variant_better"]
+                )
+                stop_now_risk = (
+                    impact["expected_daily_loss"] * BUSINESS_PROJECTION_DAYS * impact["prob_control_better"]
+                )
+                stop_now_total = stop_now_uplift + stop_now_risk
+
+                rev_col1, rev_col2, rev_col3 = st.columns(3)
+                rev_col1.metric(
+                    f"Value if you stop now ({BUSINESS_PROJECTION_DAYS}d)", f"€{stop_now_total:,.0f}"
+                )
+                rev_col2.metric("Expected Uplift", f"€{stop_now_uplift:,.0f}")
+                rev_col3.metric("Expected Risk", f"€{stop_now_risk:,.0f}")
+                st.caption(
+                    "Bayesian projection: current posterior CR × log-normal AOV, weighted by your "
+                    "lift-plausibility prior, extrapolated over a 6-month horizon at the observed "
+                    "daily traffic rate. Directional, not a guarantee — same logic as the Business "
+                    "Case page."
+                )
+
+                if est_days is not None:
+                    waiting_gain = impact["expected_daily_gain"] * est_days
+                    waiting_risk = impact["expected_daily_loss"] * est_days
+                    st.info(
+                        f"⏳ **Cost of waiting:** continuing for the estimated **{est_days:.1f} more "
+                        f"days** to reach a decision puts roughly **€{waiting_gain:,.0f} of upside** "
+                        f"and **€{waiting_risk:,.0f} of downside** on the table before you know the "
+                        f"outcome."
+                    )
 
     if chart_data:
         final_chart_df = pd.concat(chart_data)


### PR DESCRIPTION
## Summary
- Ports the Beta-posterior + log-normal AOV business-case simulation from `experiment_analysis.py` into the mSPRT sequential testing page (`pages/sequential_analysis.py`), so a stop/continue decision also surfaces an estimated revenue impact.
- Adds an ad-hoc "Revenue Impact Settings" expander (AOV, AOV variability, optional lift-skepticism prior) that sits on top of the locked test — it never affects alpha/beta/tau or the LLR decision itself.
- Adds a per-variant "Revenue Impact" card showing a 6-month value-if-you-stop-now projection (uplift/risk/total contribution) and a cost-of-waiting figure derived from the page's existing days-to-decision estimate.
- One-sample tests treat the baseline as a fixed rate rather than a posterior, consistent with how the existing LLR calculation already treats `p0`.

## Test plan
- [x] `python -m py_compile pages/sequential_analysis.py` passes
- [x] Isolated unit-level exercise of `estimate_revenue_impact()` covering: clear-winner variant, clear-loser variant, one-sample vs. fixed baseline, zero-traffic edge case (no crash/div-by-zero), and skeptical-vs-uninformative lift prior on an extreme small-sample lift (confirms the prior meaningfully dampens the estimate)
- [ ] Manual click-through in a running Streamlit + Supabase environment (not available in this sandbox — no Supabase credentials)
