### PR TITLE
Remove stale TODO in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,4 @@ plotly
 patsy
 db-dtypes
 pydantic>=2.0.0
-# TODO: point back to @main once first-order-engine PR #6
-# (estimate_monetary_impact_per_variant) merges.
 foe @ git+https://github.com/BasLinders/first-order-engine.git@main


### PR DESCRIPTION
## Summary
- The `foe` git pin already resolved to `@main` when PRs #74/#75 merged (confirmed by reading `main`'s current `requirements.txt`), but a leftover `# TODO: point back to @main once first-order-engine PR #6 merges` comment was still sitting above the already-correct line. Removes it — nothing left to do.


---
_Generated by [Claude Code](https://claude.ai/code/session_019WrsQ1eukartsGUUu3wmnU)_