### PR TITLE
Preserve admin_authenticated across the BigQuery OAuth redirect

### DIFF
--- a/pages/automation.py
+++ b/pages/automation.py
@@ -65,7 +65,11 @@ def _render_stage_fetch():
         "exactly one control (A) and one variation (B)."
     )
 
-    if not render_gcp_credentials_gate("automation"):
+    # The OAuth redirect starts a fresh Streamlit session with a blank
+    # session_state, which would otherwise look logged out of the admin gate
+    # even though the user never left it. extra_state carries admin_authenticated
+    # across that redirect — see render_gcp_credentials_gate.
+    if not render_gcp_credentials_gate("automation", extra_state={"admin_authenticated": True}):
         return
 
     st.divider()

--- a/utility/bq_client.py
+++ b/utility/bq_client.py
@@ -59,7 +59,9 @@ def _get_redirect_base_url() -> str:
     """
     try:
         base = st.secrets["BQ_REDIRECT_URI"]
-    except (KeyError, AttributeError):
+    except Exception:
+        # Covers both a missing key and no secrets.toml existing at all
+        # (StreamlitSecretNotFoundError, a FileNotFoundError subclass).
         return "https://hexkit.streamlit.app/"
     if not isinstance(base, str):
         raise TypeError(
@@ -100,7 +102,12 @@ def _build_client_config(client_id: str, client_secret: str, redirect_uri: str) 
     }
 
 
-def get_auth_url(client_id: str, client_secret: str, page_path: str = "") -> str:
+def get_auth_url(
+    client_id: str,
+    client_secret: str,
+    page_path: str = "",
+    extra_state: Optional[dict] = None,
+) -> str:
     redirect_uri = get_redirect_uri(page_path)
     config = _build_client_config(client_id, client_secret, redirect_uri)
     flow = Flow.from_client_config(config, scopes=SCOPES, redirect_uri=redirect_uri)
@@ -111,15 +118,19 @@ def get_auth_url(client_id: str, client_secret: str, page_path: str = "") -> str
         prompt="consent",
     )
 
-    # Encode verifier, credentials, AND the originating page into state — all
-    # need to survive the redirect, and the token exchange must reuse the
-    # exact same redirect_uri that was used here.
+    # Encode verifier, credentials, the originating page, AND any caller-supplied
+    # extra_state into state — all need to survive the redirect, since it starts
+    # a fresh Streamlit session with none of this in session state. extra_state
+    # lets a caller (e.g. an admin-gated page) carry its own session flags
+    # (e.g. admin_authenticated) across that same discontinuity — see
+    # exchange_code_for_credentials, which restores them into session state.
     verifier: str = getattr(flow, "code_verifier", None) or ""
     state_data = json.dumps({
         "verifier":      verifier,
         "client_id":     client_id,
         "client_secret": client_secret,
         "page_path":     page_path,
+        "extra":         extra_state or {},
     })
     encoded = base64.urlsafe_b64encode(state_data.encode()).decode().rstrip("=")
 
@@ -138,9 +149,11 @@ def exchange_code_for_credentials(
     client_id: str = "",
     client_secret: str = "",
 ) -> Credentials:
-    # Decode state — verifier, credentials, and the originating page are all embedded here
+    # Decode state — verifier, credentials, the originating page, and any
+    # caller-supplied extra_state (e.g. admin_authenticated) are all embedded here
     verifier: Optional[str] = None
     page_path = ""
+    extra_state: dict = {}
     if state:
         try:
             padding = 4 - len(state) % 4
@@ -150,6 +163,7 @@ def exchange_code_for_credentials(
             client_id     = state_data.get("client_id", client_id)
             client_secret = state_data.get("client_secret", client_secret)
             page_path     = state_data.get("page_path", "")
+            extra_state   = state_data.get("extra", {}) or {}
         except Exception:
             verifier = None
 
@@ -161,6 +175,11 @@ def exchange_code_for_credentials(
     if verifier:
         fetch_kwargs["code_verifier"] = verifier
     flow.fetch_token(**fetch_kwargs)
+
+    # Restore caller-supplied session flags now that this fresh session has a
+    # session_state to restore them into — see get_auth_url's extra_state param.
+    for key, value in extra_state.items():
+        st.session_state[key] = value
 
     creds = flow.credentials
     st.session_state["credentials"] = _creds_to_dict(creds)

--- a/utility/bq_ui_components.py
+++ b/utility/bq_ui_components.py
@@ -20,7 +20,7 @@ from utility.sql_builder import VariantPair, ExperimentConfig
 # GCP credentials gate
 # ---------------------------------------------------------------------------
 
-def render_gcp_credentials_gate(page_path: str = "") -> bool:
+def render_gcp_credentials_gate(page_path: str = "", extra_state: Optional[dict] = None) -> bool:
     """
     Renders the GCP OAuth client id/secret entry (skipped once already set)
     and the Google sign-in panel. Handles the OAuth callback itself, restoring
@@ -30,6 +30,12 @@ def render_gcp_credentials_gate(page_path: str = "") -> bool:
     `page_path` identifies the calling page (e.g. "data_export", "automation")
     so the sign-in flow round-trips through that page's own redirect URI
     instead of a single shared one.
+
+    `extra_state` is an optional dict of additional session_state keys/values
+    to carry across that same redirect discontinuity — e.g. an admin-gated
+    page passing {"admin_authenticated": True} so the fresh post-redirect
+    session doesn't look logged out of the admin gate. Restored by
+    exchange_code_for_credentials before this returns.
 
     Returns True once the session is fully authenticated and ready to proceed.
     Callers should `st.stop()` when this returns False.
@@ -90,14 +96,14 @@ def render_gcp_credentials_gate(page_path: str = "") -> bool:
         return False
 
     st.divider()
-    return render_auth_panel(page_path)
+    return render_auth_panel(page_path, extra_state)
 
 
 # ---------------------------------------------------------------------------
 # Auth panel
 # ---------------------------------------------------------------------------
 
-def render_auth_panel(page_path: str = "") -> bool:
+def render_auth_panel(page_path: str = "", extra_state: Optional[dict] = None) -> bool:
     """
     Renders sign-in/sign-out. Returns True if authenticated.
     The OAuth callback itself is handled by render_gcp_credentials_gate()
@@ -121,7 +127,7 @@ def render_auth_panel(page_path: str = "") -> bool:
             "You'll be taken to Google in a new tab — after signing in, "
             "continue in that tab."
         )
-        auth_url = get_auth_url(client_id, client_secret, page_path)
+        auth_url = get_auth_url(client_id, client_secret, page_path, extra_state)
         st.link_button(
             "🔐 Sign in with Google",
             auth_url,


### PR DESCRIPTION
The OAuth redirect starts a fresh Streamlit session with empty session state, so an admin using the Automation page's Google sign-in silently gets logged out of the admin gate even though they never left it and the Google sign-in itself succeeds fine.

Extends the existing state-param smuggling (verifier/client_id/ client_secret/page_path) with a generic extra_state dict so a caller can carry arbitrary session flags across that same redirect discontinuity. Automation now passes admin_authenticated through it.

Also widens the BQ_REDIRECT_URI secrets lookup to catch StreamlitSecretNotFoundError (raised when no secrets.toml exists at all), not just a missing key — it was only catching the latter.