### PR TITLE
Merge binomial/continuous export modes, share one events_* scan

### DIFF
--- a/pages/data_export.py
+++ b/pages/data_export.py
@@ -12,6 +12,7 @@ from utility.bq_client import (
     get_monthly_usage,
     run_query,
     run_preview,
+    run_combined_export,
     df_to_csv_bytes,
     export_to_sheets,
     autodetect_variants,
@@ -35,11 +36,16 @@ from utility.sql_builder import (
     ExperimentConfig,
     VariantPair,
     build_baseline,
-    build_binomial,
-    build_continuous,
     build_sequential,
     build_interaction,
     build_autodetect_variants_query,
+    binomial_shared_scan_flags,
+    build_shared_scan_select,
+    build_binomial_from_shared_scan,
+    build_continuous_from_shared_scan,
+    build_experiment_single_output_sql,
+    build_experiment_shared_scan_temp_table_sql,
+    build_experiment_session_output_sql,
 )
 
 
@@ -53,8 +59,7 @@ from utility.sql_builder import (
 
 EXPORT_MODES: list[tuple[str, str]] = [
     ("baseline",     "📊 Baseline export"),
-    ("binomial",     "🔢 Experiment — Binomial"),
-    ("continuous",   "📈 Experiment — Continuous"),
+    ("experiment",   "🔢 Experiment data (Binomial / Continuous)"),
     ("sequential",   "🔁 Sequential test"),
     ("interaction",  "🔀 Interaction export"),
 ]
@@ -197,17 +202,50 @@ def _render_baseline_inputs(
     )
 
 
-def _render_binomial_inputs(
+def _render_experiment_inputs(
     project: str,
     dataset: str,
     start_date: str,
     end_date: str,
-) -> Optional[BinomialParams]:
+) -> Optional[dict]:
+    """
+    Merged binomial + continuous mode. Checking one output behaves exactly
+    like the old dedicated binomial/continuous modes. Checking both scans
+    events_* once (shared_scan) and returns two separate result tables —
+    see _run_experiment_mode / _render_combined_execution_gate.
+    """
+    st.subheader("Output(s)")
+    col1, col2 = st.columns(2)
+    with col1:
+        want_binomial = st.checkbox(
+            "Binomial (aggregated conversion counts per variant)",
+            value=True,
+            key="exp_want_binomial",
+            help="Visitor and conversion counts per variant, for conversion-rate KPIs.",
+        )
+    with col2:
+        want_continuous = st.checkbox(
+            "Continuous (row-level RPV / RPT data)",
+            value=False,
+            key="exp_want_continuous",
+            help="One row per user (or user-transaction), for revenue-per-visitor or revenue-per-transaction analysis.",
+        )
+
+    if not want_binomial and not want_continuous:
+        st.warning("Select at least one output — Binomial, Continuous, or both.")
+        return None
+
+    if want_binomial and want_continuous:
+        st.info(
+            "Both outputs selected — events_* is scanned once and shared between them, "
+            "instead of scanning it twice.",
+            icon="💡",
+        )
 
     param_key, match_strategy, exp_prefix, experiments = render_variant_inputs(
         project, dataset, start_date, end_date,
-        key_prefix="bin",
-        show_multi_experiment=True,
+        key_prefix="exp",
+        show_multi_experiment=want_binomial and not want_continuous,
     )
     match_strategy = cast(Literal["exact", "like"], match_strategy)
 
@@ -216,117 +254,90 @@ def _render_binomial_inputs(
         "Post-exposure filtering",
         value=True,
         help="Only count events that occurred after the user's first experiment exposure. Recommended.",
-        key="bin_post_exposure",
+        key="exp_post_exposure",
     )
 
-    st.divider()
-    kpis = render_kpi_checkboxes(
-        project, dataset, start_date, end_date,
-        key_prefix="bin_kpi",
-        show_device_split=True,
-    )
+    binomial_params: Optional[BinomialParams] = None
+    continuous_params: Optional[ContinuousParams] = None
+
+    if want_binomial:
+        st.divider()
+        kpis = render_kpi_checkboxes(
+            project, dataset, start_date, end_date,
+            key_prefix="exp_bin_kpi",
+            show_device_split=True,
+        )
+        binomial_params = BinomialParams(
+            project=project,
+            dataset=dataset,
+            start_date=start_date,
+            end_date=end_date,
+            param_key=param_key,
+            match_strategy=match_strategy,
+            experiments=experiments,
+            post_exposure_filter=post_exposure,
+            kpi_transactions=kpis.get("kpi_transactions", True),
+            kpi_add_to_cart=kpis.get("kpi_add_to_cart", True),
+            kpi_aov=kpis.get("kpi_aov", True),
+            kpi_ideal=kpis.get("kpi_ideal", False),
+            kpi_device_split=kpis.get("kpi_device_split", True),
+            kpi_login=kpis.get("kpi_login", False),
+            kpi_create_account=kpis.get("kpi_create_account", False),
+        )
+
+    if want_continuous:
+        st.divider()
+        col1, col2 = st.columns(2)
+        with col1:
+            device_filter = cast(
+                Literal["all", "desktop", "mobile"],
+                st.radio(
+                    "Device filter",
+                    options=["all", "desktop", "mobile"],
+                    format_func=str.capitalize,
+                    horizontal=True,
+                    key="exp_cont_device_filter",
+                    help="Applied at query level — only the selected device type is returned.",
+                ),
+            )
+        with col2:
+            query_mode = cast(
+                Literal["all_users", "revenue_only"],
+                st.radio(
+                    "Query mode",
+                    options=["all_users", "revenue_only"],
+                    format_func=lambda x: (
+                        "All exposed users (revenue per visitor)"
+                        if x == "all_users"
+                        else "Users with revenue only (revenue per transaction)"
+                    ),
+                    key="exp_cont_query_mode",
+                    help=(
+                        "All exposed users: LEFT JOIN on purchases — non-buyers get revenue = 0. "
+                        "Use this for revenue-per-visitor analysis where zero values matter. "
+                        "Revenue only: INNER JOIN — excludes non-buyers entirely. "
+                        "Use this for revenue-per-transaction analysis."
+                    ),
+                ),
+            )
+        continuous_params = ContinuousParams(
+            project=project,
+            dataset=dataset,
+            start_date=start_date,
+            end_date=end_date,
+            param_key=param_key,
+            match_strategy=match_strategy,
+            experiments=experiments,
+            device_filter=device_filter,
+            query_mode=query_mode,
+            post_exposure_filter=post_exposure,
+        )
 
     if not _experiments_valid(experiments):
         st.warning("All experiments need at least two filled variant strings to continue.")
         return None
 
-    return BinomialParams(
-        project=project,
-        dataset=dataset,
-        start_date=start_date,
-        end_date=end_date,
-        param_key=param_key,
-        match_strategy=match_strategy,
-        experiments=experiments,
-        post_exposure_filter=post_exposure,
-        kpi_transactions=kpis.get("kpi_transactions", True),
-        kpi_add_to_cart=kpis.get("kpi_add_to_cart", True),
-        kpi_aov=kpis.get("kpi_aov", True),
-        kpi_ideal=kpis.get("kpi_ideal", False),
-        kpi_device_split=kpis.get("kpi_device_split", True),
-        kpi_login=kpis.get("kpi_login", False),
-        kpi_create_account=kpis.get("kpi_create_account", False),
-    )
-
-
-def _render_continuous_inputs(
-    project: str,
-    dataset: str,
-    start_date: str,
-    end_date: str,
-) -> Optional[ContinuousParams]:
-
-    st.info(
-        "Continuous queries return one row per user (or user-transaction). "
-        "Review the preview and scan estimate before running.",
-        icon="💡",
-    )
-
-    param_key, match_strategy, exp_prefix, experiments = render_variant_inputs(
-        project, dataset, start_date, end_date,
-        key_prefix="cont",
-        show_multi_experiment=False,
-    )
-    match_strategy = cast(Literal["exact", "like"], match_strategy)
-
-    st.divider()
-    post_exposure = st.toggle(
-        "Post-exposure filtering",
-        value=True,
-        help="Only count purchases that occurred after the user's first exposure.",
-        key="cont_post_exposure",
-    )
-
-    col1, col2 = st.columns(2)
-    with col1:
-        device_filter = cast(
-            Literal["all", "desktop", "mobile"],
-            st.radio(
-                "Device filter",
-                options=["all", "desktop", "mobile"],
-                format_func=str.capitalize,
-                horizontal=True,
-                key="cont_device_filter",
-                help="Applied at query level — only the selected device type is returned.",
-            ),
-        )
-    with col2:
-        query_mode = cast(
-            Literal["all_users", "revenue_only"],
-            st.radio(
-                "Query mode",
-                options=["all_users", "revenue_only"],
-                format_func=lambda x: (
-                    "All exposed users (revenue per visitor)"
-                    if x == "all_users"
-                    else "Users with revenue only (revenue per transaction)"
-                ),
-                key="cont_query_mode",
-                help=(
-                    "All exposed users: LEFT JOIN on purchases — non-buyers get revenue = 0. "
-                    "Use this for revenue-per-visitor analysis where zero values matter. "
-                    "Revenue only: INNER JOIN — excludes non-buyers entirely. "
-                    "Use this for revenue-per-transaction analysis."
-                ),
-            ),
-        )
-
-    if not _experiments_valid(experiments):
-        st.warning("Configure at least one experiment with filled variant strings to continue.")
-        return None
-
-    return ContinuousParams(
-        project=project,
-        dataset=dataset,
-        start_date=start_date,
-        end_date=end_date,
-        param_key=param_key,
-        match_strategy=match_strategy,
-        experiments=experiments,
-        device_filter=device_filter,
-        query_mode=query_mode,
-        post_exposure_filter=post_exposure,
-    )
+    return {"binomial": binomial_params, "continuous": continuous_params}
 
 
 def _render_sequential_inputs(
@@ -574,16 +585,14 @@ def _experiments_valid(experiments: list[ExperimentConfig]) -> bool:
 
 def _build_sql(
     mode: str,
-    params: Union[
-        BaselineParams, BinomialParams, ContinuousParams,
-        SequentialParams, InteractionParams,
-    ],
+    params: Union[BaselineParams, SequentialParams, InteractionParams],
 ) -> str:
-    """Route params to the correct SQL builder."""
+    """Route params to the correct SQL builder. Experiment mode (binomial /
+    continuous, one or both) is handled separately by _run_experiment_mode —
+    it needs a shared events_* scan and, when both outputs are selected, a
+    different (session-based) execution path than the other modes here."""
     builders = {
         "baseline":    lambda p: build_baseline(p),
-        "binomial":    lambda p: build_binomial(p),
-        "continuous":  lambda p: build_continuous(p),
         "sequential":  lambda p: build_sequential(p),
         "interaction": lambda p: build_interaction(p),
     }
@@ -722,6 +731,126 @@ def _render_execution_gate(
         _render_export_row(df_result, result_key, project)
 
 
+def _run_experiment_mode(project: str, dataset: str, selected: dict) -> None:
+    """
+    Builds and executes SQL for the merged binomial/continuous "Experiment
+    data" mode. One output selected -> a single ordinary query (shared_scan
+    as a plain CTE), routed through the existing single-result execution
+    gate below, same as any other mode. Both selected -> shared_scan is
+    materialized once via a BigQuery session and each output is read from
+    it as its own query, via _render_combined_execution_gate.
+    """
+    bp: Optional[BinomialParams] = selected.get("binomial")
+    cp: Optional[ContinuousParams] = selected.get("continuous")
+    ref = bp or cp
+    if ref is None:
+        return  # _render_experiment_inputs already guards against this
+
+    need_page_location, need_payment_type = binomial_shared_scan_flags(bp)
+    shared_scan_select = build_shared_scan_select(
+        ref.project, ref.dataset, ref.start_date, ref.end_date, ref.param_key,
+        need_page_location, need_payment_type,
+    )
+
+    if bp and cp:
+        create_temp_sql = build_experiment_shared_scan_temp_table_sql(shared_scan_select)
+        binomial_sql   = build_experiment_session_output_sql(build_binomial_from_shared_scan(bp))
+        continuous_sql = build_experiment_session_output_sql(build_continuous_from_shared_scan(cp))
+
+        render_sql_viewer(
+            f"{create_temp_sql}\n{binomial_sql}\n{continuous_sql}",
+            key="experiment_combined_sql",
+        )
+        _render_combined_execution_gate(
+            project, dataset, shared_scan_select, create_temp_sql,
+            {"binomial": binomial_sql, "continuous": continuous_sql},
+        )
+    else:
+        label = "binomial" if bp else "continuous"
+        chain = build_binomial_from_shared_scan(bp) if bp else build_continuous_from_shared_scan(cp)
+        sql = build_experiment_single_output_sql(shared_scan_select, chain)
+
+        render_sql_viewer(sql, key=f"experiment_{label}_sql")
+        _render_execution_gate(project, dataset, sql, f"experiment_{label}")
+
+
+def _render_combined_execution_gate(
+    project: str,
+    dataset: str,
+    shared_scan_select: str,
+    create_temp_sql: str,
+    select_sqls: dict[str, str],
+) -> None:
+    """
+    Pre-execution check + run for the two-output (binomial + continuous)
+    case. Dry-runs the bare shared-scan probe for a real cost estimate
+    (unlike sequential mode's script, which BQ can't dry-run at all), then
+    runs the shared scan once via a BigQuery session and both outputs
+    against it, storing each result under its own session-state key.
+    """
+    st.divider()
+    st.subheader("Pre-execution check")
+
+    with st.spinner("Estimating scan cost…"):
+        cost = dry_run(project, shared_scan_select)
+
+    if cost["error"]:
+        st.error(f"Dry-run failed: {cost['error']}")
+        return
+
+    with st.spinner("Fetching monthly usage…"):
+        usage = get_monthly_usage(project, dataset)
+
+    col1, col2, col3 = st.columns(3)
+    with col1:
+        st.metric(
+            "Shared scan (both outputs)",
+            cost["display"],
+            help="Estimated bytes scanned once and reused for both outputs — this is the whole query cost, not per-output.",
+        )
+    with col2:
+        st.metric(
+            "Used this month",
+            usage["used_display"] if not usage["error"] else "Unavailable",
+        )
+    with col3:
+        st.metric(
+            "Remaining free tier",
+            usage["remaining_display"] if not usage["error"] else "Unavailable",
+        )
+
+    if not usage["error"]:
+        used_pct = usage["used_pct"] / 100
+        st.progress(
+            min(used_pct, 1.0),
+            text=f"{usage['used_display']} of 1 TB used this month ({usage['used_pct']}%)",
+        )
+
+    st.caption(
+        "Preview isn't available for the combined output — cost is dominated by the "
+        "shared scan above, not by row count."
+    )
+
+    st.markdown("---")
+    if st.button("✅ Run full query", type="primary", key="experiment_combined_run"):
+        with st.spinner("Running the shared scan, then both outputs…"):
+            try:
+                results = run_combined_export(project, create_temp_sql, select_sqls)
+                for label, df in results.items():
+                    st.session_state[f"experiment_{label}_result"] = df
+                st.session_state.pop(f"monthly_usage_{project}", None)
+                st.success(", ".join(f"{label}: {len(df):,} rows" for label, df in results.items()))
+            except Exception as e:
+                st.error(f"Query failed: {e}")
+
+    for label in select_sqls:
+        df_result = st.session_state.get(f"experiment_{label}_result")
+        if df_result is not None:
+            st.subheader(label.capitalize())
+            st.dataframe(df_result, use_container_width=True)
+            _render_export_row(df_result, f"experiment_{label}", project)
+
+
 def _render_export_row(df, key_prefix: str, project: str) -> None:
     st.subheader("Export")
     col1, col2 = st.columns(2)
@@ -786,8 +915,8 @@ def run() -> None:
         key="export_mode",
         help=(
             "Baseline: aggregate site metrics for sample size planning — no experiment variables needed. "
-            "Binomial: aggregated conversion counts per variant for transaction rate and binary KPIs. "
-            "Continuous: row-level data per user for revenue per visitor or per transaction analysis. "
+            "Experiment data: binomial (aggregated conversion counts per variant), continuous (row-level "
+            "RPV/RPT data), or both from a single shared scan of events_*. "
             "Sequential: binomial export with optional persistence for sequential testing across runs. "
             "Interaction: classify users by variant combination across multiple simultaneous experiments."
         ),
@@ -799,8 +928,7 @@ def run() -> None:
 
     dispatch = {
         "baseline":    _render_baseline_inputs,
-        "binomial":    _render_binomial_inputs,
-        "continuous":  _render_continuous_inputs,
+        "experiment":  _render_experiment_inputs,
         "sequential":  _render_sequential_inputs,
         "interaction": _render_interaction_inputs,
     }
@@ -809,6 +937,10 @@ def run() -> None:
 
     if params is None:
         st.stop()
+
+    if mode == "experiment":
+        _run_experiment_mode(project, dataset, params)
+        return
 
     # --- SQL preview ---------------------------------------------------------
     sql = _build_sql(mode, params)

--- a/utility/bq_client.py
+++ b/utility/bq_client.py
@@ -445,6 +445,47 @@ def run_query(project: str, sql: str) -> "pd.DataFrame":
     return job.result().to_dataframe()
 
 
+def create_scan_session(project: str, create_temp_table_sql: str) -> str:
+    """
+    Runs a `CREATE TEMP TABLE ... AS SELECT ...` statement with a BigQuery
+    session enabled, waits for it to finish, and returns the session_id so
+    later queries can read that temp table via run_query_in_session.
+    """
+    client = get_bq_client(project)
+    job_config = bigquery.QueryJobConfig(create_session=True)
+    job = client.query(create_temp_table_sql, job_config=job_config)
+    job.result()
+    return job.session_info.session_id
+
+
+def run_query_in_session(project: str, sql: str, session_id: str) -> "pd.DataFrame":
+    """Runs a query against an existing BigQuery session (e.g. to read a
+    TEMP TABLE created by create_scan_session) and returns a DataFrame."""
+    client = get_bq_client(project)
+    job_config = bigquery.QueryJobConfig(
+        connection_properties=[bigquery.ConnectionProperty(key="session_id", value=session_id)]
+    )
+    job = client.query(sql, job_config=job_config)
+    return job.result().to_dataframe()
+
+
+def run_combined_export(
+    project: str,
+    create_temp_sql: str,
+    select_sqls: dict[str, str],
+) -> dict[str, "pd.DataFrame"]:
+    """
+    Materializes the shared scan once (via a BigQuery session), then runs
+    each labeled SELECT against it in that same session — e.g.
+    {"binomial": df, "continuous": df} — billing the big scan only once.
+    """
+    session_id = create_scan_session(project, create_temp_sql)
+    return {
+        label: run_query_in_session(project, sql, session_id)
+        for label, sql in select_sqls.items()
+    }
+
+
 def run_preview(project: str, sql: str, limit: int = 25) -> "pd.DataFrame":
     """
     Strips trailing semicolons, appends LIMIT, runs the query.

--- a/utility/sql_builder.py
+++ b/utility/sql_builder.py
@@ -752,6 +752,474 @@ ORDER BY ed.purchase_revenue DESC{limit_clause};
 
 
 # ---------------------------------------------------------------------------
+# SHARED SCAN — one-pass read of events_* backing both binomial and continuous
+# ---------------------------------------------------------------------------
+# When a user wants binomial AND continuous output for the same experiment,
+# both would otherwise independently re-scan events_* (and, internally,
+# build_binomial itself already re-scans it once per KPI CTE). These
+# functions factor that scan out once; build_*_from_shared_scan then read
+# from a `shared_scan` relation instead of the raw table. The caller decides
+# whether `shared_scan` is a CTE (single output, one ordinary query) or a
+# session-scoped TEMP TABLE (both outputs, two queries against one scan) —
+# these functions don't know or care which.
+
+def binomial_shared_scan_flags(p: Optional[BinomialParams]) -> tuple[bool, bool]:
+    """
+    Returns (need_page_location, need_payment_type) — the extra columns
+    build_binomial_from_shared_scan needs for its cost-warning KPIs
+    (login/create-account use page_location, iDEAL uses payment_type).
+    Continuous has no equivalent KPIs, so this only depends on binomial.
+    """
+    if p is None:
+        return (False, False)
+    return (p.kpi_login or p.kpi_create_account, p.kpi_ideal)
+
+
+def build_shared_scan_select(
+    project: str,
+    dataset: str,
+    start_date: str,
+    end_date: str,
+    param_key: str,
+    need_page_location: bool = False,
+    need_payment_type: bool = False,
+) -> str:
+    """
+    Bare SELECT — no CREATE TABLE / WITH wrapper — over events_* for the date
+    range, no event_name filter (matches the union of what every downstream
+    CTE in build_binomial/build_continuous already scans independently).
+    Used three ways by callers: as-is for a dry-run cost probe, wrapped in
+    `WITH shared_scan AS (...)` for the single-output case, or wrapped in
+    `CREATE TEMP TABLE shared_scan AS ...` for the two-output session case.
+    """
+    table = _table_ref(project, dataset)
+    suffix = _suffix_filter(start_date, end_date)
+
+    optional_cols = ""
+    if need_page_location:
+        optional_cols += """,
+    (SELECT p.value.string_value
+     FROM UNNEST(event_params) AS p
+     WHERE p.key = 'page_location'
+     LIMIT 1) AS page_location"""
+    if need_payment_type:
+        optional_cols += """,
+    (SELECT p.value.string_value
+     FROM UNNEST(event_params) AS p
+     WHERE p.key = 'payment_type'
+     LIMIT 1) AS payment_type"""
+
+    return f"""SELECT
+    user_pseudo_id,
+    event_name,
+    event_timestamp,
+    ecommerce.transaction_id      AS transaction_id,
+    ecommerce.purchase_revenue    AS purchase_revenue,
+    ecommerce.total_item_quantity AS total_item_quantity,
+    device.category               AS device_category,
+    (SELECT p.value.string_value
+     FROM UNNEST(event_params) AS p
+     WHERE p.key = '{param_key}'
+     LIMIT 1) AS exp_variant_string{optional_cols}
+  FROM {table}
+  WHERE {suffix}
+    AND user_pseudo_id IS NOT NULL"""
+
+
+def build_binomial_from_shared_scan(p: BinomialParams) -> str:
+    """
+    Same output as build_binomial, but every CTE reads FROM shared_scan
+    instead of independently re-scanning the raw table. Returns the CTE
+    chain body WITHOUT a leading `WITH` keyword or trailing semicolon —
+    the caller prepends `WITH shared_scan AS (...),` (single output) or
+    `WITH ` (shared_scan already a temp table, two-output session case).
+    """
+    exp = p.experiments[0]
+
+    all_variant_strings = [v.string for v in exp.variants]
+    variant_in_list = ", ".join(f"'{s}'" for s in all_variant_strings)
+
+    if p.match_strategy == "like":
+        exp_filter = f"AND exp_variant_string LIKE '%{exp.prefix}%'"
+    else:
+        exp_filter = f"AND exp_variant_string IN ({variant_in_list})"
+
+    case_block = _variant_case_block(exp, p.match_strategy, source_col="exp_variant_string")
+
+    ts_col = "event_timestamp AS first_exposure_timestamp," if p.post_exposure_filter else ""
+
+    exposure_ctes = f"""
+user_initial_exposure AS (
+  SELECT
+    user_pseudo_id,
+    exp_variant_string,
+    event_timestamp,
+    ROW_NUMBER() OVER (
+      PARTITION BY user_pseudo_id
+      ORDER BY event_timestamp ASC
+    ) AS rn
+  FROM shared_scan
+  WHERE exp_variant_string IS NOT NULL
+    {exp_filter}
+),
+
+variant_data AS (
+  SELECT
+    user_pseudo_id AS variant_user_pseudo_id,
+    {ts_col}
+    CASE
+{case_block}
+      ELSE 'Other'
+    END AS experience_variant_label
+  FROM user_initial_exposure
+  WHERE rn = 1
+),
+"""
+
+    ecommerce_cte  = ""
+    ecommerce_join = ""
+    device_cte     = ""
+    device_join    = ""
+    optional_ctes  = ""
+    optional_joins = ""
+
+    need_ecommerce = p.kpi_transactions or p.kpi_aov
+
+    if need_ecommerce:
+        if p.post_exposure_filter:
+            ecommerce_cte = f"""
+ecommerce_data AS (
+  SELECT
+    e.user_pseudo_id AS ecommerce_user_pseudo_id,
+    SUM(e.purchase_revenue)          AS purchase_revenue,
+    COUNT(DISTINCT e.transaction_id) AS transaction_id
+  FROM shared_scan e
+  INNER JOIN variant_data vd ON e.user_pseudo_id = vd.variant_user_pseudo_id
+  WHERE e.event_name = 'purchase'
+    AND e.event_timestamp >= vd.first_exposure_timestamp
+  GROUP BY e.user_pseudo_id
+),
+"""
+        else:
+            ecommerce_cte = f"""
+ecommerce_data AS (
+  SELECT
+    user_pseudo_id AS ecommerce_user_pseudo_id,
+    SUM(purchase_revenue)          AS purchase_revenue,
+    COUNT(DISTINCT transaction_id) AS transaction_id
+  FROM shared_scan
+  WHERE event_name = 'purchase'
+  GROUP BY user_pseudo_id
+),
+"""
+        ecommerce_join = "  LEFT JOIN ecommerce_data ed ON vd.variant_user_pseudo_id = ed.ecommerce_user_pseudo_id\n"
+
+    if p.kpi_device_split:
+        device_cte = f"""
+device_data AS (
+  SELECT
+    user_pseudo_id AS device_user_pseudo_id,
+    MAX(CASE WHEN device_category = 'mobile'  THEN 1 ELSE 0 END) AS is_mobile_user,
+    MAX(CASE WHEN device_category = 'desktop' THEN 1 ELSE 0 END) AS is_desktop_user
+  FROM shared_scan
+  GROUP BY user_pseudo_id
+),
+"""
+        device_join = "  LEFT JOIN device_data dd ON vd.variant_user_pseudo_id = dd.device_user_pseudo_id\n"
+
+    if p.kpi_add_to_cart:
+        if p.post_exposure_filter:
+            optional_ctes += f"""
+add_to_cart_data AS (
+  SELECT e.user_pseudo_id AS atc_user_pseudo_id
+  FROM shared_scan e
+  INNER JOIN variant_data vd ON e.user_pseudo_id = vd.variant_user_pseudo_id
+  WHERE e.event_name = 'add_to_cart'
+    AND e.event_timestamp >= vd.first_exposure_timestamp
+  GROUP BY e.user_pseudo_id
+),
+"""
+        else:
+            optional_ctes += f"""
+add_to_cart_data AS (
+  SELECT user_pseudo_id AS atc_user_pseudo_id
+  FROM shared_scan
+  WHERE event_name = 'add_to_cart'
+  GROUP BY user_pseudo_id
+),
+"""
+        optional_joins += "  LEFT JOIN add_to_cart_data atc ON vd.variant_user_pseudo_id = atc.atc_user_pseudo_id\n"
+
+    if p.kpi_login:
+        if p.post_exposure_filter:
+            optional_ctes += f"""
+login_data AS (
+  SELECT e.user_pseudo_id AS login_user_pseudo_id, 1 AS has_logged_in
+  FROM shared_scan e
+  INNER JOIN variant_data vd ON e.user_pseudo_id = vd.variant_user_pseudo_id
+  WHERE e.event_name = 'page_view'
+    AND e.page_location LIKE '%/customer/account/login%'
+    AND e.event_timestamp >= vd.first_exposure_timestamp
+  GROUP BY 1
+),
+"""
+        else:
+            optional_ctes += f"""
+login_data AS (
+  SELECT user_pseudo_id AS login_user_pseudo_id, 1 AS has_logged_in
+  FROM shared_scan
+  WHERE event_name = 'page_view'
+    AND page_location LIKE '%/customer/account/login%'
+  GROUP BY 1
+),
+"""
+        optional_joins += "  LEFT JOIN login_data ld ON vd.variant_user_pseudo_id = ld.login_user_pseudo_id\n"
+
+    if p.kpi_create_account:
+        if p.post_exposure_filter:
+            optional_ctes += f"""
+create_account_data AS (
+  SELECT e.user_pseudo_id AS create_user_pseudo_id, 1 AS has_created_account
+  FROM shared_scan e
+  INNER JOIN variant_data vd ON e.user_pseudo_id = vd.variant_user_pseudo_id
+  WHERE e.event_name = 'page_view'
+    AND e.page_location LIKE '%/customer/account/register%'
+    AND e.event_timestamp >= vd.first_exposure_timestamp
+  GROUP BY 1
+),
+"""
+        else:
+            optional_ctes += f"""
+create_account_data AS (
+  SELECT user_pseudo_id AS create_user_pseudo_id, 1 AS has_created_account
+  FROM shared_scan
+  WHERE event_name = 'page_view'
+    AND page_location LIKE '%/customer/account/register%'
+  GROUP BY 1
+),
+"""
+        optional_joins += "  LEFT JOIN create_account_data cd ON vd.variant_user_pseudo_id = cd.create_user_pseudo_id\n"
+
+    if p.kpi_ideal:
+        if p.post_exposure_filter:
+            optional_ctes += f"""
+ideal_users AS (
+  SELECT DISTINCT e.user_pseudo_id
+  FROM shared_scan e
+  INNER JOIN variant_data vd ON e.user_pseudo_id = vd.variant_user_pseudo_id
+  WHERE e.event_name = 'add_payment_info'
+    AND e.payment_type LIKE '%iDEAL%'
+    AND e.event_timestamp >= vd.first_exposure_timestamp
+),
+"""
+        else:
+            optional_ctes += f"""
+ideal_users AS (
+  SELECT DISTINCT user_pseudo_id
+  FROM shared_scan
+  WHERE event_name = 'add_payment_info'
+    AND payment_type LIKE '%iDEAL%'
+),
+"""
+        optional_joins += "  LEFT JOIN ideal_users iu ON vd.variant_user_pseudo_id = iu.user_pseudo_id\n"
+
+    final_cols = [
+        "    vd.variant_user_pseudo_id",
+        "    vd.experience_variant_label",
+    ]
+    if need_ecommerce:
+        final_cols += [
+            "    ed.transaction_id  AS transaction_id",
+            "    ed.purchase_revenue AS purchase_revenue",
+        ]
+    if p.kpi_device_split:
+        final_cols += [
+            "    dd.is_mobile_user",
+            "    dd.is_desktop_user",
+        ]
+    if p.kpi_add_to_cart:
+        final_cols.append(
+            "    CASE WHEN atc.atc_user_pseudo_id IS NOT NULL THEN 1 ELSE 0 END AS has_added_to_cart"
+        )
+    if p.kpi_ideal:
+        final_cols.append(
+            "    CASE WHEN iu.user_pseudo_id IS NOT NULL THEN 1 ELSE 0 END AS paid_with_ideal"
+        )
+    if p.kpi_login:
+        final_cols.append("    COALESCE(ld.has_logged_in, 0) AS has_logged_in")
+    if p.kpi_create_account:
+        final_cols.append("    COALESCE(cd.has_created_account, 0) AS has_created_account")
+
+    final_select = ",\n".join(final_cols)
+
+    select_cols = [
+        "  experience_variant_label",
+        "  COUNT(DISTINCT variant_user_pseudo_id) AS visitors",
+    ]
+    if p.kpi_transactions:
+        select_cols += [
+            "  COUNT(DISTINCT CASE WHEN transaction_id IS NOT NULL THEN variant_user_pseudo_id END) AS users_with_transaction",
+            "  SUM(CASE WHEN transaction_id IS NOT NULL THEN transaction_id ELSE 0 END) AS total_transactions",
+        ]
+    if p.kpi_aov:
+        select_cols.append(
+            "  ROUND(SUM(purchase_revenue) / NULLIF(SUM(CASE WHEN transaction_id IS NOT NULL THEN transaction_id ELSE 0 END), 0), 2) AS average_order_value"
+        )
+    if p.kpi_device_split:
+        select_cols += [
+            "  COUNT(DISTINCT CASE WHEN is_mobile_user  = 1 THEN variant_user_pseudo_id END) AS mobile_users",
+            "  COUNT(DISTINCT CASE WHEN is_desktop_user = 1 THEN variant_user_pseudo_id END) AS desktop_users",
+        ]
+        if p.kpi_transactions:
+            select_cols += [
+                "  COUNT(DISTINCT CASE WHEN is_mobile_user  = 1 AND transaction_id IS NOT NULL THEN variant_user_pseudo_id END) AS mobile_buyers",
+                "  COUNT(DISTINCT CASE WHEN is_desktop_user = 1 AND transaction_id IS NOT NULL THEN variant_user_pseudo_id END) AS desktop_buyers",
+            ]
+    if p.kpi_add_to_cart:
+        select_cols.append("  SUM(has_added_to_cart) AS add_to_cart")
+    if p.kpi_ideal:
+        select_cols.append("  SUM(paid_with_ideal) AS paid_with_ideal")
+    if p.kpi_login:
+        select_cols.append("  SUM(has_logged_in) AS login_page_visits")
+    if p.kpi_create_account:
+        select_cols.append("  SUM(has_created_account) AS account_creation_page_visits")
+
+    select_block = ",\n".join(select_cols)
+
+    return f"""{exposure_ctes}{ecommerce_cte}{device_cte}{optional_ctes}
+final_data AS (
+  SELECT
+{final_select}
+  FROM variant_data vd
+{ecommerce_join}{device_join}{optional_joins}  WHERE vd.experience_variant_label != 'Other'
+)
+
+SELECT
+{select_block}
+FROM final_data
+GROUP BY experience_variant_label
+ORDER BY experience_variant_label"""
+
+
+def build_continuous_from_shared_scan(p: ContinuousParams) -> str:
+    """
+    Same output as build_continuous, but sourced from shared_scan instead of
+    independently scanning the raw table twice (single_scan + device_data).
+    Returns the CTE chain body WITHOUT a leading `WITH` keyword or trailing
+    semicolon — see build_binomial_from_shared_scan for the wrapping contract.
+    """
+    exp = p.experiments[0]
+
+    all_variant_strings = [v.string for v in exp.variants]
+    variant_in_list = ", ".join(f"'{s}'" for s in all_variant_strings)
+
+    if p.match_strategy == "like":
+        exp_filter = f"AND exp_variant_string LIKE '%{exp.prefix}%'"
+    else:
+        exp_filter = f"AND exp_variant_string IN ({variant_in_list})"
+
+    case_lines = []
+    for v in exp.variants:
+        op = "LIKE" if p.match_strategy == "like" else "="
+        case_lines.append(f"      WHEN exp_variant_string {op} '{v.string}' THEN '{v.label}'")
+    case_block = "\n".join(case_lines)
+
+    join_type = "INNER JOIN" if p.query_mode == "revenue_only" else "LEFT JOIN"
+
+    return f"""
+user_initial_exposure AS (
+  SELECT
+    user_pseudo_id,
+    exp_variant_string,
+    ROW_NUMBER() OVER (PARTITION BY user_pseudo_id ORDER BY event_timestamp ASC) AS rn
+  FROM shared_scan
+  WHERE exp_variant_string IS NOT NULL
+    {exp_filter}
+),
+
+variant_data AS (
+  SELECT
+    user_pseudo_id,
+    CASE
+{case_block}
+      ELSE 'Other'
+    END AS experience_variant_label
+  FROM user_initial_exposure
+  WHERE rn = 1
+    AND CASE
+{case_block}
+          ELSE 'Other'
+        END != 'Other'
+),
+
+device_data AS (
+  SELECT
+    user_pseudo_id AS device_user_pseudo_id,
+    CASE
+      WHEN COUNTIF(device_category = 'desktop') >= COUNTIF(device_category = 'mobile') THEN 'desktop'
+      ELSE 'mobile'
+    END AS primary_device
+  FROM shared_scan
+  WHERE device_category IN ('desktop', 'mobile')
+  GROUP BY user_pseudo_id
+),
+
+ecommerce_data AS (
+  SELECT
+    user_pseudo_id,
+    transaction_id,
+    SUM(purchase_revenue)    AS purchase_revenue,
+    SUM(total_item_quantity) AS total_item_quantity
+  FROM shared_scan
+  WHERE event_name = 'purchase'
+    AND purchase_revenue IS NOT NULL
+    AND purchase_revenue <> 0.0
+  GROUP BY user_pseudo_id, transaction_id
+)
+
+SELECT
+  vd.user_pseudo_id        AS variant_user_pseudo_id,
+  vd.experience_variant_label,
+  ed.purchase_revenue,
+  ed.total_item_quantity,
+  ed.transaction_id
+FROM variant_data vd
+{join_type} ecommerce_data ed ON vd.user_pseudo_id = ed.user_pseudo_id
+INNER JOIN device_data      dd ON vd.user_pseudo_id = dd.device_user_pseudo_id
+WHERE ('{p.device_filter}' = 'all' OR dd.primary_device = '{p.device_filter}')
+ORDER BY ed.purchase_revenue DESC"""
+
+
+def build_experiment_single_output_sql(shared_scan_select: str, cte_chain: str, limit: int = 0) -> str:
+    """Wraps a from-shared-scan CTE chain for the one-output case: shared_scan
+    as an ordinary CTE, one query, no BigQuery session required."""
+    limit_clause = f"\nLIMIT {limit}" if limit else ""
+    return f"""-- Experiment export (shared scan, single output)
+WITH shared_scan AS (
+{shared_scan_select}
+),
+{cte_chain}{limit_clause};
+"""
+
+
+def build_experiment_shared_scan_temp_table_sql(shared_scan_select: str) -> str:
+    """Wraps the shared-scan SELECT as a session-scoped TEMP TABLE, for the
+    two-output case — materialized once, read by two separate queries."""
+    return f"""-- Experiment export (shared scan, materialized for two outputs)
+CREATE TEMP TABLE shared_scan AS
+{shared_scan_select};
+"""
+
+
+def build_experiment_session_output_sql(cte_chain: str, limit: int = 0) -> str:
+    """Wraps a from-shared-scan CTE chain to run as its own query against an
+    already-materialized `shared_scan` temp table within a BigQuery session."""
+    limit_clause = f"\nLIMIT {limit}" if limit else ""
+    return f"""WITH {cte_chain}{limit_clause};
+"""
+
+
+# ---------------------------------------------------------------------------
 # SEQUENTIAL
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Requesting both binomial and continuous experiment data used to mean two independent full scans of events_* for the same date range and variant exposure. The Data Export page now offers one "Experiment data" mode with checkboxes for either output; selecting both routes through a single shared scan (materialized once via a BigQuery session) instead of paying for it twice. Selecting just one output still runs as a single ordinary query, and picks up a smaller win too since the binomial KPI CTEs no longer each re-scan the raw table.