### PR TITLE
Add binomial/continuous choice and a real Continuous Analysis method …

### DIFF
--- a/pages/automation.py
+++ b/pages/automation.py
@@ -10,7 +10,7 @@ if not st.session_state.get("admin_authenticated") and "code" not in st.query_pa
 
 import json
 import math
-from typing import Literal, cast
+from typing import Literal, Optional, cast
 
 import pandas as pd
 
@@ -20,20 +20,26 @@ from utility.bq_ui_components import (
     render_date_range,
     render_variant_inputs,
     render_execution_gate,
+    render_combined_execution_gate,
     render_sql_viewer,
 )
 from utility.sql_builder import (
     BinomialParams,
+    ContinuousParams,
     binomial_shared_scan_flags,
     build_shared_scan_select,
     build_binomial_from_shared_scan,
+    build_continuous_from_shared_scan,
     build_experiment_single_output_sql,
+    build_experiment_shared_scan_temp_table_sql,
+    build_experiment_session_output_sql,
 )
 from utility.automation_engine import (
     VariantData,
     TAILS,
     run_frequentist_analysis,
     run_bayesian_analysis,
+    run_continuous_analysis,
     build_airtable_payload,
 )
 from utility.airtable_client import get_credentials, push_record
@@ -67,8 +73,8 @@ def _render_stepper(stage: int):
 def _render_stage_fetch():
     st.subheader("Step 1 — Fetch data from BigQuery")
     st.caption(
-        "Runs the same binomial export used in Data Export, restricted to "
-        "exactly one control (A) and one variation (B)."
+        "Same experiment data as Data Export's binomial/continuous modes, "
+        "restricted to exactly one control (A) and one variation (B)."
     )
 
     # The OAuth redirect starts a fresh Streamlit session with a blank
@@ -88,6 +94,33 @@ def _render_stage_fetch():
     start_date, end_date = render_date_range()
 
     st.divider()
+    st.subheader("Data to fetch")
+    col1, col2 = st.columns(2)
+    with col1:
+        want_binomial = st.checkbox(
+            "Binomial (conversion rate / AOV)",
+            value=True,
+            key="autofetch_want_binomial",
+            help="Enables Frequentist and Bayesian analysis in the next step.",
+        )
+    with col2:
+        want_continuous = st.checkbox(
+            "Continuous (revenue per visitor)",
+            value=False,
+            key="autofetch_want_continuous",
+            help="Enables Continuous Analysis in the next step.",
+        )
+    if not want_binomial and not want_continuous:
+        st.warning("Select at least one data set — Binomial, Continuous, or both.")
+        return
+    if want_binomial and want_continuous:
+        st.info(
+            "Both selected — events_* is scanned once and shared between them, "
+            "instead of scanning it twice.",
+            icon="💡",
+        )
+
+    st.divider()
     param_key, match_strategy, exp_prefix, experiments = render_variant_inputs(
         project, dataset, start_date, end_date,
         key_prefix="autofetch",
@@ -104,45 +137,89 @@ def _render_stage_fetch():
         )
         return
 
-    params = BinomialParams(
-        project=project,
-        dataset=dataset,
-        start_date=start_date,
-        end_date=end_date,
-        param_key=param_key,
-        match_strategy=cast(Literal["exact", "like"], match_strategy),
-        experiments=experiments,
-        post_exposure_filter=True,
-        kpi_transactions=True,
-        kpi_aov=True,
-        kpi_add_to_cart=False,
-        kpi_ideal=False,
-        kpi_device_split=False,
-        kpi_login=False,
-        kpi_create_account=False,
-    )
-    need_page_location, need_payment_type = binomial_shared_scan_flags(params)
+    match_strategy = cast(Literal["exact", "like"], match_strategy)
+
+    binomial_params: Optional[BinomialParams] = None
+    if want_binomial:
+        binomial_params = BinomialParams(
+            project=project,
+            dataset=dataset,
+            start_date=start_date,
+            end_date=end_date,
+            param_key=param_key,
+            match_strategy=match_strategy,
+            experiments=experiments,
+            post_exposure_filter=True,
+            kpi_transactions=True,
+            kpi_aov=True,
+            kpi_add_to_cart=False,
+            kpi_ideal=False,
+            kpi_device_split=False,
+            kpi_login=False,
+            kpi_create_account=False,
+        )
+
+    continuous_params: Optional[ContinuousParams] = None
+    if want_continuous:
+        continuous_params = ContinuousParams(
+            project=project,
+            dataset=dataset,
+            start_date=start_date,
+            end_date=end_date,
+            param_key=param_key,
+            match_strategy=match_strategy,
+            experiments=experiments,
+            device_filter="all",
+            query_mode="all_users",  # RPV — non-buyers included, matches run_continuous_analysis's per-visitor assumption
+            post_exposure_filter=True,
+        )
+
+    need_page_location, need_payment_type = binomial_shared_scan_flags(binomial_params)
     shared_scan_select = build_shared_scan_select(
         project, dataset, start_date, end_date, param_key,
         need_page_location, need_payment_type,
     )
-    sql = build_experiment_single_output_sql(shared_scan_select, build_binomial_from_shared_scan(params))
-    render_sql_viewer(sql, key="auto_sql")
 
-    render_execution_gate(project, sql, result_key="auto_query_result", allow_preview=True)
+    if binomial_params and continuous_params:
+        create_temp_sql = build_experiment_shared_scan_temp_table_sql(shared_scan_select)
+        binomial_sql   = build_experiment_session_output_sql(build_binomial_from_shared_scan(binomial_params))
+        continuous_sql = build_experiment_session_output_sql(build_continuous_from_shared_scan(continuous_params))
 
-    df = st.session_state.get("auto_query_result")
-    if df is None:
+        render_sql_viewer(
+            f"{create_temp_sql}\n{binomial_sql}\n{continuous_sql}",
+            key="auto_sql",
+        )
+        render_combined_execution_gate(
+            project, dataset, shared_scan_select, create_temp_sql,
+            {"binomial": binomial_sql, "continuous": continuous_sql},
+            result_key_prefix="auto",
+        )
+    else:
+        label = "binomial" if binomial_params else "continuous"
+        chain = (
+            build_binomial_from_shared_scan(binomial_params) if binomial_params
+            else build_continuous_from_shared_scan(continuous_params)
+        )
+        sql = build_experiment_single_output_sql(shared_scan_select, chain)
+        render_sql_viewer(sql, key="auto_sql")
+        render_execution_gate(project, sql, result_key=f"auto_{label}_result", allow_preview=True)
+
+    df_binomial = st.session_state.get("auto_binomial_result")
+    df_continuous = st.session_state.get("auto_continuous_result")
+    if df_binomial is None and df_continuous is None:
         return
 
-    row_labels = set(df["experience_variant_label"])
-    if not {"A", "B"}.issubset(row_labels):
-        st.error("Query result is missing rows for control (A) and/or variation (B).")
+    if df_binomial is not None and not {"A", "B"}.issubset(set(df_binomial["experience_variant_label"])):
+        st.error("Binomial result is missing rows for control (A) and/or variation (B).")
+        return
+    if df_continuous is not None and not {"A", "B"}.issubset(set(df_continuous["experience_variant_label"])):
+        st.error("Continuous result is missing rows for control (A) and/or variation (B).")
         return
 
     st.divider()
     if st.button("Continue to choose analysis method(s) →", type="primary"):
-        st.session_state["auto_df"] = df
+        st.session_state["auto_df_binomial"] = df_binomial
+        st.session_state["auto_df_continuous"] = df_continuous
         st.session_state["auto_stage"] = 2
         st.rerun()
 
@@ -162,54 +239,93 @@ def _variant_from_row(row, label: str) -> VariantData:
 
 
 def _render_stage_configure():
-    df = st.session_state.get("auto_df")
-    if df is None:
+    df_binomial = st.session_state.get("auto_df_binomial")
+    df_continuous = st.session_state.get("auto_df_continuous")
+    if df_binomial is None and df_continuous is None:
         st.session_state["auto_stage"] = 1
         st.rerun()
         return
 
     st.subheader("Step 2 — Choose analysis method(s)")
 
-    control = _variant_from_row(df[df["experience_variant_label"] == "A"].iloc[0], "Control")
-    variation = _variant_from_row(df[df["experience_variant_label"] == "B"].iloc[0], "Variation")
+    control = variation = None
+    if df_binomial is not None:
+        control = _variant_from_row(df_binomial[df_binomial["experience_variant_label"] == "A"].iloc[0], "Control")
+        variation = _variant_from_row(df_binomial[df_binomial["experience_variant_label"] == "B"].iloc[0], "Variation")
 
-    col1, col2 = st.columns(2)
-    with col1:
-        st.metric("Control — visitors", f"{control.visitors:,}")
-        rate = control.conversions / control.visitors if control.visitors else 0.0
-        st.metric("Control — conversions", f"{control.conversions:,}", help=f"Rate: {rate:.2%}")
-        st.metric("Control — AOV", f"€{control.aov:,.2f}")
-    with col2:
-        st.metric("Variation — visitors", f"{variation.visitors:,}")
-        rate = variation.conversions / variation.visitors if variation.visitors else 0.0
-        st.metric("Variation — conversions", f"{variation.conversions:,}", help=f"Rate: {rate:.2%}")
-        st.metric("Variation — AOV", f"€{variation.aov:,.2f}")
+        col1, col2 = st.columns(2)
+        with col1:
+            st.metric("Control — visitors", f"{control.visitors:,}")
+            rate = control.conversions / control.visitors if control.visitors else 0.0
+            st.metric("Control — conversions", f"{control.conversions:,}", help=f"Rate: {rate:.2%}")
+            st.metric("Control — AOV", f"€{control.aov:,.2f}")
+        with col2:
+            st.metric("Variation — visitors", f"{variation.visitors:,}")
+            rate = variation.conversions / variation.visitors if variation.visitors else 0.0
+            st.metric("Variation — conversions", f"{variation.conversions:,}", help=f"Rate: {rate:.2%}")
+            st.metric("Variation — AOV", f"€{variation.aov:,.2f}")
+
+    if df_continuous is not None:
+        st.markdown("**Continuous data — revenue per visitor**")
+        cont_summary = (
+            df_continuous.assign(purchase_revenue=pd.to_numeric(df_continuous["purchase_revenue"], errors="coerce").fillna(0.0))
+            .groupby("experience_variant_label")["purchase_revenue"]
+            .agg(["mean", "count"])
+            .rename(columns={"mean": "revenue per visitor", "count": "visitors"})
+        )
+        st.dataframe(cont_summary, use_container_width=True)
 
     st.divider()
     st.markdown("**Analysis method(s)**")
-    c1, c2, c3 = st.columns(3)
+    c1, c2, c3, c4 = st.columns(4)
     with c1:
-        use_frequentist = st.checkbox("Frequentist Analysis", value=True, key="auto_use_frequentist")
+        use_frequentist = st.checkbox(
+            "Frequentist Analysis", value=df_binomial is not None,
+            disabled=df_binomial is None, key="auto_use_frequentist",
+            help=None if df_binomial is not None else "Requires binomial data — fetch it in step 1.",
+        )
     with c2:
-        use_bayesian = st.checkbox("Bayesian Analysis", value=True, key="auto_use_bayesian")
+        use_bayesian = st.checkbox(
+            "Bayesian Analysis", value=df_binomial is not None,
+            disabled=df_binomial is None, key="auto_use_bayesian",
+            help=None if df_binomial is not None else "Requires binomial data — fetch it in step 1.",
+        )
     with c3:
+        use_continuous = st.checkbox(
+            "Continuous Analysis", value=df_continuous is not None,
+            disabled=df_continuous is None, key="auto_use_continuous",
+            help=None if df_continuous is not None else "Requires continuous data — fetch it in step 1.",
+        )
+    with c4:
         st.checkbox(
             "Pre-Test Analysis", value=False, disabled=True,
             key="auto_use_pretest", help="Coming soon.",
         )
 
-    if not use_frequentist and not use_bayesian:
+    # Streamlit persists a checkbox's checked state across reruns even while
+    # disabled=True, so a method checked before a re-fetch dropped its data
+    # would otherwise stay "on" here despite being greyed out in the UI.
+    use_frequentist = use_frequentist and df_binomial is not None
+    use_bayesian = use_bayesian and df_binomial is not None
+    use_continuous = use_continuous and df_continuous is not None
+
+    if not use_frequentist and not use_bayesian and not use_continuous:
         st.warning("Select at least one analysis method to continue.")
         return
 
     start = st.session_state.get("start_date")
     end = st.session_state.get("end_date")
     runtime_days = max((end - start).days + 1, 1) if start and end else 1
-    daily_visitors = (control.visitors + variation.visitors) / runtime_days
+    if control is not None and variation is not None:
+        total_visitors = control.visitors + variation.visitors
+    else:
+        # Per-visitor rows (RPV query mode) — one row per exposed user.
+        total_visitors = len(df_continuous)
+    daily_visitors = total_visitors / runtime_days
 
     st.divider()
-    if use_frequentist:
-        with st.expander("Frequentist settings", expanded=True):
+    if use_frequentist or use_continuous:
+        with st.expander("Significance settings", expanded=True):
             fc1, fc2 = st.columns(2)
             with fc1:
                 confidence_level = st.slider(
@@ -248,17 +364,22 @@ def _render_stage_configure():
             )
         st.caption(f"Test runtime: {runtime_days} day(s) · Daily visitors: {daily_visitors:,.0f}")
 
-    revenue_source = "frequentist"
-    if use_frequentist and use_bayesian:
+    active_methods = [
+        m for m, using in (
+            ("Frequentist", use_frequentist),
+            ("Bayesian", use_bayesian),
+            ("Continuous", use_continuous),
+        ) if using
+    ]
+    revenue_source = active_methods[0].lower()
+    if len(active_methods) > 1:
         choice = st.radio(
             "Use for the shared 'effect on revenue' field:",
-            options=["Frequentist", "Bayesian"],
+            options=active_methods,
             horizontal=True,
             key="auto_revenue_source_radio",
         )
         revenue_source = choice.lower()
-    elif use_bayesian:
-        revenue_source = "bayesian"
 
     st.divider()
     col_back, col_next = st.columns(2)
@@ -285,6 +406,16 @@ def _render_stage_configure():
                     projection_days=int(projection_days),
                     n_samples=int(n_samples),
                 )
+            if use_continuous:
+                results["continuous"] = run_continuous_analysis(
+                    df_continuous,
+                    control_label="A",
+                    variation_label="B",
+                    daily_visitors=daily_visitors,
+                    projection_days=int(projection_days),
+                    confidence_level=confidence_level,
+                    tail=tail,
+                )
             st.session_state["auto_control"] = control
             st.session_state["auto_variation"] = variation
             st.session_state["auto_results"] = results
@@ -305,7 +436,7 @@ def _render_stage_results():
     results = st.session_state.get("auto_results")
     control = st.session_state.get("auto_control")
     variation = st.session_state.get("auto_variation")
-    if not results or control is None or variation is None:
+    if not results:
         st.session_state["auto_stage"] = 2
         st.rerun()
         return
@@ -314,6 +445,7 @@ def _render_stage_results():
 
     freq = results.get("frequentist")
     bayes = results.get("bayesian")
+    cont = results.get("continuous")
 
     if freq:
         st.markdown("### Frequentist")
@@ -346,8 +478,23 @@ def _render_stage_results():
         st.caption(bayes["conclusion"])
         st.divider()
 
+    if cont:
+        st.markdown("### Continuous")
+        c1, c2, c3 = st.columns(3)
+        c1.metric("Test used", cont["test_name"])
+        c2.metric("P-value", f"{cont['p_value']:.4f}")
+        c3.metric("Significant?", "Yes" if cont["is_significant"] else "No")
+        ci_low, ci_high = cont["effect_on_revenue_ci"]
+        st.metric(
+            f"Effect on revenue ({cont['projection_days']}d)",
+            _fmt_money(cont["effect_on_revenue"]),
+            help=f"CI: {_fmt_money(ci_low)} to {_fmt_money(ci_high)}",
+        )
+        st.caption(cont["conclusion"])
+        st.divider()
+
     revenue_source = st.session_state.get("auto_revenue_source", "frequentist")
-    payload = build_airtable_payload(control, variation, freq, bayes, revenue_source=revenue_source)
+    payload = build_airtable_payload(control, variation, freq, bayes, cont, revenue_source=revenue_source)
     st.session_state["auto_payload"] = payload
 
     st.markdown("**Airtable payload preview**")

--- a/pages/data_export.py
+++ b/pages/data_export.py
@@ -12,7 +12,6 @@ from utility.bq_client import (
     get_monthly_usage,
     run_query,
     run_preview,
-    run_combined_export,
     df_to_csv_bytes,
     export_to_sheets,
     autodetect_variants,
@@ -26,6 +25,7 @@ from utility.bq_ui_components import (
     render_kpi_checkboxes,
     render_sql_viewer,
     render_export_options,
+    render_combined_execution_gate,
 )
 from utility.sql_builder import (
     BaselineParams,
@@ -738,7 +738,7 @@ def _run_experiment_mode(project: str, dataset: str, selected: dict) -> None:
     as a plain CTE), routed through the existing single-result execution
     gate below, same as any other mode. Both selected -> shared_scan is
     materialized once via a BigQuery session and each output is read from
-    it as its own query, via _render_combined_execution_gate.
+    it as its own query, via the shared render_combined_execution_gate.
     """
     bp: Optional[BinomialParams] = selected.get("binomial")
     cp: Optional[ContinuousParams] = selected.get("continuous")
@@ -761,9 +761,10 @@ def _run_experiment_mode(project: str, dataset: str, selected: dict) -> None:
             f"{create_temp_sql}\n{binomial_sql}\n{continuous_sql}",
             key="experiment_combined_sql",
         )
-        _render_combined_execution_gate(
+        render_combined_execution_gate(
             project, dataset, shared_scan_select, create_temp_sql,
             {"binomial": binomial_sql, "continuous": continuous_sql},
+            result_key_prefix="experiment",
         )
     else:
         label = "binomial" if bp else "continuous"
@@ -772,83 +773,6 @@ def _run_experiment_mode(project: str, dataset: str, selected: dict) -> None:
 
         render_sql_viewer(sql, key=f"experiment_{label}_sql")
         _render_execution_gate(project, dataset, sql, f"experiment_{label}")
-
-
-def _render_combined_execution_gate(
-    project: str,
-    dataset: str,
-    shared_scan_select: str,
-    create_temp_sql: str,
-    select_sqls: dict[str, str],
-) -> None:
-    """
-    Pre-execution check + run for the two-output (binomial + continuous)
-    case. Dry-runs the bare shared-scan probe for a real cost estimate
-    (unlike sequential mode's script, which BQ can't dry-run at all), then
-    runs the shared scan once via a BigQuery session and both outputs
-    against it, storing each result under its own session-state key.
-    """
-    st.divider()
-    st.subheader("Pre-execution check")
-
-    with st.spinner("Estimating scan cost…"):
-        cost = dry_run(project, shared_scan_select)
-
-    if cost["error"]:
-        st.error(f"Dry-run failed: {cost['error']}")
-        return
-
-    with st.spinner("Fetching monthly usage…"):
-        usage = get_monthly_usage(project, dataset)
-
-    col1, col2, col3 = st.columns(3)
-    with col1:
-        st.metric(
-            "Shared scan (both outputs)",
-            cost["display"],
-            help="Estimated bytes scanned once and reused for both outputs — this is the whole query cost, not per-output.",
-        )
-    with col2:
-        st.metric(
-            "Used this month",
-            usage["used_display"] if not usage["error"] else "Unavailable",
-        )
-    with col3:
-        st.metric(
-            "Remaining free tier",
-            usage["remaining_display"] if not usage["error"] else "Unavailable",
-        )
-
-    if not usage["error"]:
-        used_pct = usage["used_pct"] / 100
-        st.progress(
-            min(used_pct, 1.0),
-            text=f"{usage['used_display']} of 1 TB used this month ({usage['used_pct']}%)",
-        )
-
-    st.caption(
-        "Preview isn't available for the combined output — cost is dominated by the "
-        "shared scan above, not by row count."
-    )
-
-    st.markdown("---")
-    if st.button("✅ Run full query", type="primary", key="experiment_combined_run"):
-        with st.spinner("Running the shared scan, then both outputs…"):
-            try:
-                results = run_combined_export(project, create_temp_sql, select_sqls)
-                for label, df in results.items():
-                    st.session_state[f"experiment_{label}_result"] = df
-                st.session_state.pop(f"monthly_usage_{project}", None)
-                st.success(", ".join(f"{label}: {len(df):,} rows" for label, df in results.items()))
-            except Exception as e:
-                st.error(f"Query failed: {e}")
-
-    for label in select_sqls:
-        df_result = st.session_state.get(f"experiment_{label}_result")
-        if df_result is not None:
-            st.subheader(label.capitalize())
-            st.dataframe(df_result, use_container_width=True)
-            _render_export_row(df_result, f"experiment_{label}", project)
 
 
 def _render_export_row(df, key_prefix: str, project: str) -> None:

--- a/utility/automation_engine.py
+++ b/utility/automation_engine.py
@@ -10,9 +10,19 @@ import math
 from dataclasses import dataclass
 from typing import Literal, Optional
 
-from foe.core.models import AlternativeHypothesis, BusinessCaseInput, ExperimentInput
+import pandas as pd
+
+from foe.core.models import (
+    AlternativeHypothesis,
+    AnalysisUnit,
+    BusinessCaseInput,
+    ContinuousApproach,
+    ContinuousMetricConfig,
+    ExperimentInput,
+)
 from foe.frequentist.operations import FrequentistEngine
 from foe.bayesian.operations import BayesianEngine
+from foe.continuous.operations import ContinuousMetricEngine
 
 # Provisional — the real Airtable base's field names aren't known yet.
 # Update this mapping once they are; nothing else in this module needs to change.
@@ -23,6 +33,8 @@ AIRTABLE_FIELD_MAP = {
     "conversions_variation": "conversions - variation",
     "probability_pct": "probability (%)",
     "p_value": "p-value",
+    "continuous_p_value": "p-value (continuous)",
+    "continuous_test_name": "test used (continuous)",
     "effect_on_revenue": "effect on revenue",
 }
 
@@ -144,29 +156,104 @@ def run_bayesian_analysis(
     }
 
 
+def run_continuous_analysis(
+    df: "pd.DataFrame",
+    control_label: str,
+    variation_label: str,
+    daily_visitors: float,
+    projection_days: int,
+    confidence_level: float = 0.95,
+    tail: Literal["Two-sided", "Greater", "Less"] = "Two-sided",
+    kpi: str = "purchase_revenue",
+) -> dict:
+    """
+    Runs the FOE ContinuousMetricEngine on row-level revenue-per-visitor data
+    (the heuristic path auto-selects Mann-Whitney / ANOVA / Welch / Negative-
+    Binomial as appropriate), plus a revenue-impact projection.
+
+    Assumes per-visitor data — automation.py's continuous fetch always uses
+    the "all_users" (RPV) query mode, whose LEFT JOIN leaves non-buyers as
+    NULL rather than 0; zero-filled here so they're correctly treated as
+    non-converting visitors rather than dropped.
+    """
+    alternative = _TAIL_MAP[tail]
+    alpha = 1.0 - confidence_level
+
+    work = df.copy()
+    work[kpi] = pd.to_numeric(work[kpi], errors="coerce").fillna(0.0)
+
+    config = ContinuousMetricConfig(
+        kpi=kpi,
+        group_col="experience_variant_label",
+        approach=ContinuousApproach.HEURISTIC,
+        unit=AnalysisUnit.PER_VISITOR,
+        control_label=control_label,
+        alpha=alpha,
+    )
+    engine = ContinuousMetricEngine()
+    result = engine.run_comparison_suite(work, config)
+
+    group_stats = {row["experience_variant_label"]: row for row in result.summary_stats}
+    monetary_list = engine.run_business_case(
+        group_stats=group_stats,
+        control_label=control_label,
+        unit=AnalysisUnit.PER_VISITOR,
+        daily_visitors=daily_visitors,
+        alpha=alpha,
+        alternative=alternative,
+        projection_period=projection_days,
+        significance_by_variant={variation_label: result.is_significant},
+    )
+    monetary = next(
+        (m for m in monetary_list if m["variant"] == variation_label),
+        monetary_list[0] if monetary_list else None,
+    )
+
+    return {
+        "method": "continuous",
+        "kpi": kpi,
+        "test_name": result.test_name,
+        "p_value": result.p_value,
+        "is_significant": result.is_significant,
+        "conclusion": result.conclusion,
+        "summary_stats": result.summary_stats,
+        "effect_on_revenue": monetary["point_estimate"] if monetary else 0.0,
+        "effect_on_revenue_ci": (monetary["ci_low"], monetary["ci_high"]) if monetary else (0.0, 0.0),
+        "projection_days": projection_days,
+    }
+
+
 def build_airtable_payload(
-    control: VariantData,
-    variation: VariantData,
+    control: Optional[VariantData],
+    variation: Optional[VariantData],
     frequentist_result: Optional[dict] = None,
     bayesian_result: Optional[dict] = None,
-    revenue_source: Literal["frequentist", "bayesian"] = "frequentist",
+    continuous_result: Optional[dict] = None,
+    revenue_source: Literal["frequentist", "bayesian", "continuous"] = "frequentist",
 ) -> dict:
     """Maps engine outputs onto Airtable field names via AIRTABLE_FIELD_MAP."""
-    fields = {
-        AIRTABLE_FIELD_MAP["visitors_control"]: control.visitors,
-        AIRTABLE_FIELD_MAP["visitors_variation"]: variation.visitors,
-        AIRTABLE_FIELD_MAP["conversions_control"]: control.conversions,
-        AIRTABLE_FIELD_MAP["conversions_variation"]: variation.conversions,
-    }
+    fields: dict = {}
+    if control is not None and variation is not None:
+        fields.update({
+            AIRTABLE_FIELD_MAP["visitors_control"]: control.visitors,
+            AIRTABLE_FIELD_MAP["visitors_variation"]: variation.visitors,
+            AIRTABLE_FIELD_MAP["conversions_control"]: control.conversions,
+            AIRTABLE_FIELD_MAP["conversions_variation"]: variation.conversions,
+        })
 
     if frequentist_result:
         fields[AIRTABLE_FIELD_MAP["p_value"]] = round(frequentist_result["p_value"], 6)
     if bayesian_result:
         fields[AIRTABLE_FIELD_MAP["probability_pct"]] = round(bayesian_result["probability_pct"], 2)
+    if continuous_result:
+        fields[AIRTABLE_FIELD_MAP["continuous_p_value"]] = round(continuous_result["p_value"], 6)
+        fields[AIRTABLE_FIELD_MAP["continuous_test_name"]] = continuous_result["test_name"]
 
-    revenue_result = (
-        bayesian_result if revenue_source == "bayesian" and bayesian_result else frequentist_result
-    ) or bayesian_result
+    revenue_result = {
+        "frequentist": frequentist_result,
+        "bayesian": bayesian_result,
+        "continuous": continuous_result,
+    }.get(revenue_source) or frequentist_result or bayesian_result or continuous_result
     if revenue_result:
         fields[AIRTABLE_FIELD_MAP["effect_on_revenue"]] = round(revenue_result["effect_on_revenue"], 2)
 

--- a/utility/bq_ui_components.py
+++ b/utility/bq_ui_components.py
@@ -10,8 +10,8 @@ import streamlit as st
 from utility.bq_client import (
     is_authenticated, get_auth_url, exchange_code_for_credentials,
     get_redirect_uri, sign_out, list_projects, list_datasets, dry_run,
-    run_preview, run_query, df_to_csv_bytes, export_to_sheets,
-    autodetect_variants, autodetect_kpis
+    get_monthly_usage, run_preview, run_query, run_combined_export,
+    df_to_csv_bytes, export_to_sheets, autodetect_variants, autodetect_kpis
 )
 from utility.sql_builder import VariantPair, ExperimentConfig
 
@@ -531,6 +531,90 @@ def render_execution_gate(
     if df is not None:
         st.dataframe(df, use_container_width=True)
         render_export_options(df, result_key, project)
+
+
+# ---------------------------------------------------------------------------
+# Combined (shared-scan, two-output) execution gate
+# ---------------------------------------------------------------------------
+
+def render_combined_execution_gate(
+    project: str,
+    dataset: str,
+    shared_scan_select: str,
+    create_temp_sql: str,
+    select_sqls: dict[str, str],
+    result_key_prefix: str,
+) -> None:
+    """
+    Pre-execution check + run for the two-output (binomial + continuous)
+    shared-scan case — shared by the Data Export "Experiment data" mode and
+    the Automation wizard's fetch step. Dry-runs the bare shared-scan probe
+    for a real cost estimate (unlike a full script, which BQ can't dry-run
+    at all), then runs the shared scan once via a BigQuery session and both
+    outputs against it, storing each result under
+    f"{result_key_prefix}_{label}_result".
+    """
+    st.divider()
+    st.subheader("Pre-execution check")
+
+    with st.spinner("Estimating scan cost…"):
+        cost = dry_run(project, shared_scan_select)
+
+    if cost["error"]:
+        st.error(f"Dry-run failed: {cost['error']}")
+        return
+
+    with st.spinner("Fetching monthly usage…"):
+        usage = get_monthly_usage(project, dataset)
+
+    col1, col2, col3 = st.columns(3)
+    with col1:
+        st.metric(
+            "Shared scan (both outputs)",
+            cost["display"],
+            help="Estimated bytes scanned once and reused for both outputs — this is the whole query cost, not per-output.",
+        )
+    with col2:
+        st.metric(
+            "Used this month",
+            usage["used_display"] if not usage["error"] else "Unavailable",
+        )
+    with col3:
+        st.metric(
+            "Remaining free tier",
+            usage["remaining_display"] if not usage["error"] else "Unavailable",
+        )
+
+    if not usage["error"]:
+        used_pct = usage["used_pct"] / 100
+        st.progress(
+            min(used_pct, 1.0),
+            text=f"{usage['used_display']} of 1 TB used this month ({usage['used_pct']}%)",
+        )
+
+    st.caption(
+        "Preview isn't available for the combined output — cost is dominated by the "
+        "shared scan above, not by row count."
+    )
+
+    st.markdown("---")
+    if st.button("✅ Run full query", type="primary", key=f"{result_key_prefix}_combined_run"):
+        with st.spinner("Running the shared scan, then both outputs…"):
+            try:
+                results = run_combined_export(project, create_temp_sql, select_sqls)
+                for label, df in results.items():
+                    st.session_state[f"{result_key_prefix}_{label}_result"] = df
+                st.session_state.pop(f"monthly_usage_{project}", None)
+                st.success(", ".join(f"{label}: {len(df):,} rows" for label, df in results.items()))
+            except Exception as e:
+                st.error(f"Query failed: {e}")
+
+    for label in select_sqls:
+        df_result = st.session_state.get(f"{result_key_prefix}_{label}_result")
+        if df_result is not None:
+            st.subheader(label.capitalize())
+            st.dataframe(df_result, use_container_width=True)
+            render_export_options(df_result, f"{result_key_prefix}_{label}", project)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Step 1 (fetch) now offers the same binomial/continuous/both choice as Data Export's "Experiment data" mode, via the same shared-scan machinery — one ordinary query when only one is fetched, one BigQuery session (scan once, two outputs) when both are.

Step 2 gates the analysis methods by what was actually fetched: Frequentist and Bayesian are disabled+unchecked without binomial data; a new Continuous Analysis method (FOE's ContinuousMetricEngine — auto-selects Mann-Whitney/ANOVA/Welch/Negative-Binomial/Gamma) is enabled only when continuous data was fetched, with its own revenue-impact projection and Airtable fields (build_airtable_payload now accepts an optional continuous result and no longer requires control/variation).

The combined execution gate is factored out of data_export.py into utility/bq_ui_components.py (render_combined_execution_gate) so both pages share one implementation instead of duplicating it — data_export.py's local copy was deleted.

Verified via streamlit.testing.AppTest for all three fetch combinations (binomial-only, continuous-only, both), and all three analysis-method combinations end-to-end through to the Airtable payload — zero exceptions, correct gating, correct payload contents in each case. No live BigQuery credentials available in this environment to confirm actual bytes billed / real-data output parity.

Summary of what changed:

utility/bq_ui_components.py: new shared render_combined_execution_gate.
utility/automation_engine.py: new run_continuous_analysis; build_airtable_payload extended for optional control/variation + continuous results.
pages/automation.py: step 1 gets binomial/continuous checkboxes; step 2 gates Frequentist/Bayesian/Continuous checkboxes by fetched data (with a fix for Streamlit's checkbox-state-persists-while-disabled gotcha); step 3 shows continuous results and builds the extended payload.
pages/data_export.py: now calls the shared render_combined_execution_gate instead of its own local copy.