### PR TITLE
Discover Airtable bases/tables/fields live instead of hardcoding them

### DIFF
--- a/pages/automation.py
+++ b/pages/automation.py
@@ -37,12 +37,15 @@ from utility.sql_builder import (
 from utility.automation_engine import (
     VariantData,
     TAILS,
+    FIELD_LABELS,
     run_frequentist_analysis,
     run_bayesian_analysis,
     run_continuous_analysis,
     build_airtable_payload,
+    apply_field_map,
+    best_match_field,
 )
-from utility.airtable_client import get_credentials, push_record
+from utility.airtable_client import get_credentials, push_record, list_bases, list_tables
 
 
 STEPS = ["1. Fetch data", "2. Choose analysis", "3. Review results", "4. Send results"]
@@ -497,8 +500,8 @@ def _render_stage_results():
     payload = build_airtable_payload(control, variation, freq, bayes, cont, revenue_source=revenue_source)
     st.session_state["auto_payload"] = payload
 
-    st.markdown("**Airtable payload preview**")
-    st.caption("Field names are provisional — see `AIRTABLE_FIELD_MAP` in utility/automation_engine.py.")
+    st.markdown("**Result summary**")
+    st.caption("Airtable field names are chosen in the next step, based on the base/table you send to.")
     st.json(payload)
 
     col_back, col_next = st.columns(2)
@@ -516,6 +519,21 @@ def _render_stage_results():
 # Step 4 — Send results
 # ---------------------------------------------------------------------------
 
+def _render_json_download(payload: dict):
+    st.download_button(
+        "⬇️ Download raw result as JSON",
+        data=json.dumps(payload, indent=2).encode(),
+        file_name="automation_payload.json",
+        mime="application/json",
+    )
+
+
+def _render_back_to_results_button():
+    if st.button("← Back to results"):
+        st.session_state["auto_stage"] = 3
+        st.rerun()
+
+
 def _render_stage_send():
     payload = st.session_state.get("auto_payload")
     if payload is None:
@@ -527,47 +545,154 @@ def _render_stage_send():
 
     st.markdown("#### Airtable")
     creds = get_credentials()
-    col1, col2 = st.columns(2)
-    with col1:
-        base_id = st.text_input("Base ID", value=creds["base_id"], key="airtable_base_id")
-    with col2:
-        table_name = st.text_input("Table name", value=creds["table_name"], key="airtable_table_name")
-    api_key = st.text_input(
-        "API key (personal access token)", value=creds["api_key"],
-        type="password", key="airtable_api_key",
-    )
-    st.caption(
-        "No Airtable token is configured yet — set `AIRTABLE_API_KEY`, `AIRTABLE_BASE_ID` "
-        "and `AIRTABLE_TABLE_NAME` in Streamlit secrets to prefill these, or paste them "
-        "here for a one-off send (kept in this session only, never written to disk)."
+    api_key = creds["api_key"]
+
+    if not api_key:
+        st.warning(
+            "No Airtable token is configured — set `AIRTABLE_API_KEY` in Streamlit secrets "
+            "(a single personal access token with the `schema.bases:read` scope, granted "
+            "access to every base/workspace results should be sent to). It's an operational "
+            "secret, not something entered here."
+        )
+        st.divider()
+        _render_json_download(payload)
+        _render_back_to_results_button()
+        return
+
+    # --- Base discovery --------------------------------------------------
+    if st.session_state.get("airtable_bases_for_key") != api_key:
+        with st.spinner("Loading Airtable bases…"):
+            result = list_bases(api_key)
+        if not result["ok"]:
+            st.error(f"Couldn't list Airtable bases: {result['error']}")
+            st.divider()
+            _render_json_download(payload)
+            _render_back_to_results_button()
+            return
+        st.session_state["airtable_bases_cache"] = result["bases"]
+        st.session_state["airtable_bases_for_key"] = api_key
+
+    bases: dict = st.session_state["airtable_bases_cache"]
+    if not bases:
+        st.warning("This token can't see any bases — check its access under Airtable's token settings.")
+        st.divider()
+        _render_json_download(payload)
+        _render_back_to_results_button()
+        return
+
+    base_ids = list(bases.keys())
+    prior_base = st.session_state.get("airtable_base_id") or creds["base_id"]
+    base_id = st.selectbox(
+        "Send to (base)",
+        options=base_ids,
+        index=base_ids.index(prior_base) if prior_base in base_ids else 0,
+        format_func=lambda bid: bases.get(bid, bid),
+        key="airtable_base_id",
     )
 
-    if st.button(
-        "🚀 Send to Airtable", type="primary",
-        disabled=not (base_id and table_name and api_key),
-    ):
-        with st.spinner("Sending to Airtable…"):
-            result = push_record(base_id, table_name, api_key, payload)
-        if result["ok"]:
-            st.success(f"Record created: {result['record_id']}")
-        else:
-            st.error(f"Airtable request failed: {result['error']}")
+    # --- Table discovery ---------------------------------------------------
+    tables_cache_key = f"airtable_tables_{base_id}"
+    if tables_cache_key not in st.session_state:
+        with st.spinner("Loading tables…"):
+            result = list_tables(api_key, base_id)
+        if not result["ok"]:
+            st.error(f"Couldn't list tables in this base: {result['error']}")
+            st.divider()
+            _render_json_download(payload)
+            _render_back_to_results_button()
+            return
+        st.session_state[tables_cache_key] = result["tables"]
+
+    tables = st.session_state[tables_cache_key]
+    if not tables:
+        st.warning("This base has no tables.")
+        st.divider()
+        _render_json_download(payload)
+        _render_back_to_results_button()
+        return
+
+    table_names = [t["name"] for t in tables]
+    stored_selection = st.session_state.get("airtable_table_names", [])
+    default_selection = [n for n in stored_selection if n in table_names] or table_names[:1]
+    selected_names = st.multiselect(
+        "Tables — send this result to each one selected",
+        options=table_names,
+        default=default_selection,
+        key="airtable_table_names",
+        help="Pick every table that should receive this result — e.g. an internal "
+             "tracking table plus one or more client tables in the same base. Each "
+             "gets its own field mapping below.",
+    )
+    if not selected_names:
+        st.info("Select at least one table above to continue.")
+        st.divider()
+        _render_json_download(payload)
+        _render_back_to_results_button()
+        return
+
+    selected_tables = [t for t in tables if t["name"] in selected_names]
+
+    # --- Field assignment, one tab per selected table -----------------------
+    st.divider()
+    st.markdown("#### Field mapping")
+    st.caption(
+        "Assign each computed value to a column in each table. Remembered per "
+        "base/table, so you only need to set this up once."
+    )
+
+    field_maps: dict = {}
+    for tab, table in zip(st.tabs(selected_names), selected_tables):
+        with tab:
+            field_options = ["— Skip —"] + table["fields"]
+            mapping_key = f"airtable_fieldmap_{base_id}_{table['id']}"
+            stored_mapping: dict = st.session_state.get(mapping_key, {})
+
+            field_map: dict = {}
+            for key in payload:
+                label = FIELD_LABELS.get(key, key)
+                default = stored_mapping.get(key) or best_match_field(key, table["fields"])
+                default_idx = field_options.index(default) if default in field_options else 0
+                chosen = st.selectbox(
+                    label, options=field_options, index=default_idx,
+                    key=f"{mapping_key}_{key}",
+                )
+                if chosen != "— Skip —":
+                    field_map[key] = chosen
+
+            st.session_state[mapping_key] = field_map
+            field_maps[table["id"]] = field_map
+
+    final_fields_by_table = {
+        table["id"]: apply_field_map(payload, field_maps[table["id"]])
+        for table in selected_tables
+    }
+    ready_tables = [t for t in selected_tables if final_fields_by_table[t["id"]]]
+    skipped_tables = [t for t in selected_tables if t not in ready_tables]
+
+    with st.expander("Preview what will be sent", expanded=False):
+        st.json({t["name"]: final_fields_by_table[t["id"]] for t in selected_tables})
+
+    if st.button("🚀 Send to Airtable", type="primary", disabled=not ready_tables):
+        with st.spinner(f"Sending to {len(ready_tables)} table(s)…"):
+            send_results = [
+                (table["name"], push_record(base_id, table["id"], api_key, final_fields_by_table[table["id"]]))
+                for table in ready_tables
+            ]
+        for name, result in send_results:
+            if result["ok"]:
+                st.success(f"{name}: record created ({result['record_id']})")
+            else:
+                st.error(f"{name}: {result['error']}")
+        if skipped_tables:
+            st.caption(f"Skipped (no fields mapped): {', '.join(t['name'] for t in skipped_tables)}")
 
     st.divider()
     st.markdown("#### Other destinations")
     st.caption("More destinations (Slack, HubSpot, …) can be wired in here later.")
 
     st.divider()
-    st.download_button(
-        "⬇️ Download payload as JSON",
-        data=json.dumps(payload, indent=2).encode(),
-        file_name="automation_payload.json",
-        mime="application/json",
-    )
-
-    if st.button("← Back to results"):
-        st.session_state["auto_stage"] = 3
-        st.rerun()
+    _render_json_download(payload)
+    _render_back_to_results_button()
 
 
 # ---------------------------------------------------------------------------

--- a/utility/airtable_client.py
+++ b/utility/airtable_client.py
@@ -27,12 +27,14 @@ def _secret(key: str) -> str:
 
 def get_credentials() -> dict[str, str]:
     """
-    Reads Airtable credentials from session state first (set via the UI, since
-    no Airtable token exists yet), falling back to st.secrets:
-    AIRTABLE_API_KEY, AIRTABLE_BASE_ID, AIRTABLE_TABLE_NAME.
+    api_key is an operational secret (one PAT covers every base/workspace it's
+    been granted access to) — it only ever comes from st.secrets, never from
+    user input. base_id/table_name are just the currently selected base/table
+    (set live by the discovery dropdowns in the Send step), falling back to
+    st.secrets defaults to seed their initial selection.
     """
     return {
-        "api_key": st.session_state.get("airtable_api_key") or _secret("AIRTABLE_API_KEY"),
+        "api_key": _secret("AIRTABLE_API_KEY"),
         "base_id": st.session_state.get("airtable_base_id") or _secret("AIRTABLE_BASE_ID"),
         "table_name": st.session_state.get("airtable_table_name") or _secret("AIRTABLE_TABLE_NAME"),
     }
@@ -42,9 +44,18 @@ def is_configured() -> bool:
     return all(get_credentials().values())
 
 
+def _extract_error(resp: "requests.Response") -> str:
+    try:
+        return resp.json().get("error", {}).get("message", "")
+    except Exception:
+        return ""
+
+
 def push_record(base_id: str, table_name: str, api_key: str, fields: dict[str, Any]) -> dict:
     """
-    Creates a single record in an Airtable table.
+    Creates a single record in an Airtable table. `table_name` may be either a
+    table name or a table ID — Airtable's API accepts both in this URL slot,
+    and the Send step now passes the ID (stable across renames).
     Returns {"ok": bool, "record_id": Optional[str], "error": Optional[str]}.
     """
     url = f"{API_URL}/{base_id}/{table_name}"
@@ -57,11 +68,60 @@ def push_record(base_id: str, table_name: str, api_key: str, fields: dict[str, A
         record = resp.json()["records"][0]
         return {"ok": True, "record_id": record["id"], "error": None}
     except requests.exceptions.HTTPError as e:
-        detail = ""
-        try:
-            detail = resp.json().get("error", {}).get("message", "")
-        except Exception:
-            pass
-        return {"ok": False, "record_id": None, "error": detail or str(e)}
+        return {"ok": False, "record_id": None, "error": _extract_error(resp) or str(e)}
     except Exception as e:
         return {"ok": False, "record_id": None, "error": str(e)}
+
+
+def list_bases(api_key: str) -> dict:
+    """
+    Lists every Airtable base this PAT can see, via the metadata API
+    (GET /v0/meta/bases — requires the `schema.bases:read` scope on the token).
+    Paginates via `offset` since a token spanning many workspaces can exceed
+    the 1000-base single-page cap.
+    Returns {"ok": bool, "bases": {base_id: name}, "error": Optional[str]}.
+    """
+    headers = {"Authorization": f"Bearer {api_key}"}
+    bases: dict[str, str] = {}
+    params: dict[str, str] = {}
+    try:
+        while True:
+            resp = requests.get(f"{API_URL}/meta/bases", headers=headers, params=params, timeout=15)
+            resp.raise_for_status()
+            data = resp.json()
+            bases.update({b["id"]: b["name"] for b in data.get("bases", [])})
+            offset = data.get("offset")
+            if not offset:
+                break
+            params = {"offset": offset}
+        return {"ok": True, "bases": bases, "error": None}
+    except requests.exceptions.HTTPError as e:
+        return {"ok": False, "bases": {}, "error": _extract_error(resp) or str(e)}
+    except Exception as e:
+        return {"ok": False, "bases": {}, "error": str(e)}
+
+
+def list_tables(api_key: str, base_id: str) -> dict:
+    """
+    Lists the tables in a base, each with its field names, via the metadata
+    API (GET /v0/meta/bases/{base_id}/tables — same `schema.bases:read` scope).
+    Returns {"ok": bool, "tables": [{"id", "name", "fields": [str, ...]}], "error": Optional[str]}.
+    """
+    url = f"{API_URL}/meta/bases/{base_id}/tables"
+    headers = {"Authorization": f"Bearer {api_key}"}
+    try:
+        resp = requests.get(url, headers=headers, timeout=15)
+        resp.raise_for_status()
+        tables = [
+            {
+                "id": t["id"],
+                "name": t["name"],
+                "fields": [f["name"] for f in t.get("fields", [])],
+            }
+            for t in resp.json().get("tables", [])
+        ]
+        return {"ok": True, "tables": tables, "error": None}
+    except requests.exceptions.HTTPError as e:
+        return {"ok": False, "tables": [], "error": _extract_error(resp) or str(e)}
+    except Exception as e:
+        return {"ok": False, "tables": [], "error": str(e)}

--- a/utility/automation_engine.py
+++ b/utility/automation_engine.py
@@ -24,9 +24,25 @@ from foe.frequentist.operations import FrequentistEngine
 from foe.bayesian.operations import BayesianEngine
 from foe.continuous.operations import ContinuousMetricEngine
 
-# Provisional — the real Airtable base's field names aren't known yet.
-# Update this mapping once they are; nothing else in this module needs to change.
-AIRTABLE_FIELD_MAP = {
+# The Send step discovers each destination base/table's real field names live
+# via Airtable's metadata API (see utility/airtable_client.list_tables) and
+# lets the user assign them — no hardcoded-per-base mapping to maintain here.
+# These two dicts are just cosmetic/convenience: friendly labels for the
+# assignment UI, and a same-name-match hint to auto-preselect a sensible
+# default when a base happens to already use these names.
+FIELD_LABELS = {
+    "visitors_control": "Visitors — Control",
+    "visitors_variation": "Visitors — Variation",
+    "conversions_control": "Conversions — Control",
+    "conversions_variation": "Conversions — Variation",
+    "p_value": "P-value (Frequentist)",
+    "probability_pct": "Probability to beat control % (Bayesian)",
+    "continuous_p_value": "P-value (Continuous)",
+    "continuous_test_name": "Test used (Continuous)",
+    "effect_on_revenue": "Effect on revenue",
+}
+
+DEFAULT_FIELD_NAME_HINTS = {
     "visitors_control": "visitors - control",
     "visitors_variation": "visitors - variation",
     "conversions_control": "conversions - control",
@@ -231,23 +247,29 @@ def build_airtable_payload(
     continuous_result: Optional[dict] = None,
     revenue_source: Literal["frequentist", "bayesian", "continuous"] = "frequentist",
 ) -> dict:
-    """Maps engine outputs onto Airtable field names via AIRTABLE_FIELD_MAP."""
+    """
+    Builds the automation result keyed by internal semantic names (e.g.
+    "visitors_control", "p_value") — NOT Airtable field names. Which base and
+    table this is headed to (and therefore which field names exist) isn't
+    known yet at this point in the flow; the Send step resolves that live and
+    translates via apply_field_map.
+    """
     fields: dict = {}
     if control is not None and variation is not None:
         fields.update({
-            AIRTABLE_FIELD_MAP["visitors_control"]: control.visitors,
-            AIRTABLE_FIELD_MAP["visitors_variation"]: variation.visitors,
-            AIRTABLE_FIELD_MAP["conversions_control"]: control.conversions,
-            AIRTABLE_FIELD_MAP["conversions_variation"]: variation.conversions,
+            "visitors_control": control.visitors,
+            "visitors_variation": variation.visitors,
+            "conversions_control": control.conversions,
+            "conversions_variation": variation.conversions,
         })
 
     if frequentist_result:
-        fields[AIRTABLE_FIELD_MAP["p_value"]] = round(frequentist_result["p_value"], 6)
+        fields["p_value"] = round(frequentist_result["p_value"], 6)
     if bayesian_result:
-        fields[AIRTABLE_FIELD_MAP["probability_pct"]] = round(bayesian_result["probability_pct"], 2)
+        fields["probability_pct"] = round(bayesian_result["probability_pct"], 2)
     if continuous_result:
-        fields[AIRTABLE_FIELD_MAP["continuous_p_value"]] = round(continuous_result["p_value"], 6)
-        fields[AIRTABLE_FIELD_MAP["continuous_test_name"]] = continuous_result["test_name"]
+        fields["continuous_p_value"] = round(continuous_result["p_value"], 6)
+        fields["continuous_test_name"] = continuous_result["test_name"]
 
     revenue_result = {
         "frequentist": frequentist_result,
@@ -255,6 +277,37 @@ def build_airtable_payload(
         "continuous": continuous_result,
     }.get(revenue_source) or frequentist_result or bayesian_result or continuous_result
     if revenue_result:
-        fields[AIRTABLE_FIELD_MAP["effect_on_revenue"]] = round(revenue_result["effect_on_revenue"], 2)
+        fields["effect_on_revenue"] = round(revenue_result["effect_on_revenue"], 2)
 
     return fields
+
+
+def apply_field_map(payload: dict, field_map: dict) -> dict:
+    """
+    Translates an internal-key payload (from build_airtable_payload) into
+    Airtable's actual field names for the chosen base/table, per field_map
+    (internal key -> Airtable field name). Keys with no chosen mapping are
+    omitted rather than sent under their internal name.
+    """
+    return {
+        field_map[key]: value
+        for key, value in payload.items()
+        if field_map.get(key)
+    }
+
+
+def best_match_field(internal_key: str, available_fields: list) -> Optional[str]:
+    """
+    Case-insensitive exact match of internal_key's default hint (see
+    DEFAULT_FIELD_NAME_HINTS) against a table's real field names — used only
+    to auto-preselect a sensible default in the assignment UI. Returns None
+    if there's no hint or no match, leaving the choice to the user.
+    """
+    hint = DEFAULT_FIELD_NAME_HINTS.get(internal_key, "")
+    if not hint:
+        return None
+    hint_lower = hint.lower()
+    for field in available_fields:
+        if field.lower() == hint_lower:
+            return field
+    return None


### PR DESCRIPTION
The Send step now uses Airtable's metadata API (GET /v0/meta/bases, GET /v0/meta/bases/{id}/tables) so the app discovers, live, every base and table a token can see and each table's real field names — no static per-base field-name mapping to maintain in code or a spreadsheet. Field assignment auto-matches by name where possible and otherwise defaults to Skip, remembered per base/table so repeat sends don't need re-mapping.

The API token is now strictly a Streamlit secret (AIRTABLE_API_KEY) — removed the manual entry field entirely, since one token already covers every workspace it's been granted access to.

Table selection is a multiselect: the same result can be sent to several tables at once (e.g. an internal tracking table plus one or more client tables), each with its own independent field mapping shown in its own tab. Sending skips any selected table with nothing mapped rather than pushing an empty record, and reports success/failure per table.