### PR TITLE
Route continuous revenue analysis through Gamma GLM, add RPV/RPT choice

### DIFF
--- a/pages/automation.py
+++ b/pages/automation.py
@@ -353,6 +353,26 @@ def _render_stage_configure():
     else:
         n_samples = 100_000
 
+    if use_continuous:
+        with st.expander("Continuous settings", expanded=True):
+            continuous_mode = st.radio(
+                "Metric definition",
+                options=["rpv", "rpt"],
+                format_func=lambda m: (
+                    "Revenue per visitor (RPV)" if m == "rpv" else "Revenue per transaction (RPT)"
+                ),
+                horizontal=True,
+                key="auto_continuous_mode",
+                help=(
+                    "RPV: every exposed visitor counts, non-buyers as €0 — captures both "
+                    "conversion-rate and spend effects together. RPT: only buyers count "
+                    "(zero-revenue rows stripped before analysis) — isolates the order-value "
+                    "effect alone. Both use the same fetched data; only the calculation differs."
+                ),
+            )
+    else:
+        continuous_mode = "rpv"
+
     with st.expander("Revenue projection", expanded=True):
         rc1, rc2 = st.columns(2)
         with rc1:
@@ -418,6 +438,7 @@ def _render_stage_configure():
                     projection_days=int(projection_days),
                     confidence_level=confidence_level,
                     tail=tail,
+                    mode=continuous_mode,
                 )
             st.session_state["auto_control"] = control
             st.session_state["auto_variation"] = variation
@@ -482,7 +503,8 @@ def _render_stage_results():
         st.divider()
 
     if cont:
-        st.markdown("### Continuous")
+        mode_label = "RPV" if cont.get("mode", "rpv") == "rpv" else "RPT"
+        st.markdown(f"### Continuous ({mode_label})")
         c1, c2, c3 = st.columns(3)
         c1.metric("Test used", cont["test_name"])
         c2.metric("P-value", f"{cont['p_value']:.4f}")

--- a/utility/automation_engine.py
+++ b/utility/automation_engine.py
@@ -181,28 +181,50 @@ def run_continuous_analysis(
     confidence_level: float = 0.95,
     tail: Literal["Two-sided", "Greater", "Less"] = "Two-sided",
     kpi: str = "purchase_revenue",
+    mode: Literal["rpv", "rpt"] = "rpv",
 ) -> dict:
     """
-    Runs the FOE ContinuousMetricEngine on row-level revenue-per-visitor data
-    (the heuristic path auto-selects Mann-Whitney / ANOVA / Welch / Negative-
-    Binomial as appropriate), plus a revenue-impact projection.
+    Runs the FOE ContinuousMetricEngine on row-level revenue data via the
+    Gamma / two-part likelihood-ratio path (rather than the generic heuristic
+    decision tree), since revenue is non-negative and right-skewed — the
+    Gamma family models that shape directly instead of picking a generic test
+    via a normality/variance decision tree. Also computes a revenue-impact
+    projection.
 
-    Assumes per-visitor data — automation.py's continuous fetch always uses
-    the "all_users" (RPV) query mode, whose LEFT JOIN leaves non-buyers as
-    NULL rather than 0; zero-filled here so they're correctly treated as
-    non-converting visitors rather than dropped.
+    automation.py's continuous fetch always uses the "all_users" (LEFT JOIN)
+    query mode, so every exposed visitor is a row, non-buyers as NULL revenue
+    (zero-filled below) rather than dropped — this is what makes both modes
+    below possible from the *same* fetched data:
+
+    mode="rpv" (revenue per visitor): every row counts as-is — measures
+    conversion-rate AND spend effects together (AnalysisUnit.PER_VISITOR).
+    mode="rpt" (revenue per transaction): only buyers should count, so zero-
+    revenue rows are stripped before analysis (AnalysisUnit.PER_TRANSACTION)
+    — isolates the order-value effect alone. Each variant's total exposed
+    visitor count is taken from the data *before* that stripping and passed
+    through to the monetary projection regardless of mode, since FOE's
+    PER_TRANSACTION business case needs it to derive an order rate (n
+    orders / total visitors) — without it, a per-order lift can't be scaled
+    to daily traffic.
     """
     alternative = _TAIL_MAP[tail]
     alpha = 1.0 - confidence_level
 
     work = df.copy()
     work[kpi] = pd.to_numeric(work[kpi], errors="coerce").fillna(0.0)
+    visitor_counts = work["experience_variant_label"].value_counts().to_dict()
+
+    if mode == "rpt":
+        work = work[work[kpi] != 0.0]
+        unit = AnalysisUnit.PER_TRANSACTION
+    else:
+        unit = AnalysisUnit.PER_VISITOR
 
     config = ContinuousMetricConfig(
         kpi=kpi,
         group_col="experience_variant_label",
-        approach=ContinuousApproach.HEURISTIC,
-        unit=AnalysisUnit.PER_VISITOR,
+        approach=ContinuousApproach.GAMMA_GLM,
+        unit=unit,
         control_label=control_label,
         alpha=alpha,
     )
@@ -213,8 +235,9 @@ def run_continuous_analysis(
     monetary_list = engine.run_business_case(
         group_stats=group_stats,
         control_label=control_label,
-        unit=AnalysisUnit.PER_VISITOR,
+        unit=unit,
         daily_visitors=daily_visitors,
+        visitor_counts=visitor_counts,
         alpha=alpha,
         alternative=alternative,
         projection_period=projection_days,
@@ -227,6 +250,7 @@ def run_continuous_analysis(
 
     return {
         "method": "continuous",
+        "mode": mode,
         "kpi": kpi,
         "test_name": result.test_name,
         "p_value": result.p_value,


### PR DESCRIPTION
## Summary
- Continuous revenue analysis now runs through FOE's Gamma/two-part likelihood-ratio path (ContinuousApproach.GAMMA_GLM) instead of the generic heuristic decision tree, since revenue is non-negative and right-skewed rather than a good fit for normality/variance-based test selection.
- Added an RPV/RPT choice for continuous analysis, exposed as a "Continuous settings" radio in Step 2 of the automation wizard:
  - RPV (revenue per visitor): every exposed visitor counts, non-buyers as €0 — measures conversion-rate and spend effects together.
  - RPT (revenue per transaction): only buyers count, zero-revenue rows are stripped before analysis — isolates the order-value effect alone.
- Each variant's total exposed-visitor count is captured before the RPT strip and passed through to the monetary projection, since FOE's per-transaction business case needs it to derive an order rate and scale the lift to daily traffic.
- Step 3 results now label which mode ran ("Continuous (RPV)" / "Continuous (RPT)").

## Test plan
- Verified with synthetic Gamma-shaped revenue data that RPV counts every visitor while RPT counts only buyers (zero-stripping confirmed exact)
- Verified RPV/RPT effect_on_revenue point estimates match exactly (expected identity) while confidence intervals differ (RPT wider, reflecting order-rate uncertainty)
- AppTest run through the full wizard: radio renders with correct default (RPV), selecting RPT threads mode="rpt" through to the computed result and the Step 3 header