### PR TITLE
Fix Automation feedback batch: proportions, field matching, revenue s…

### DIFF
--- a/pages/automation.py
+++ b/pages/automation.py
@@ -1075,8 +1075,8 @@ def _render_stage_send():
             table_names = [t["name"] for t in tables]
             names_key = f"airtable_table_names_{base_id}"
             stored_selection = st.session_state.get(names_key, [])
-            experiment_tables = [n for n in table_names if n.lower() == "experiment"] or [
-                n for n in table_names if "experiment" in n.lower()
+            experiment_tables = [n for n in table_names if n.lower() == "experiments"] or [
+                n for n in table_names if "experiments" in n.lower()
             ]
             default_selection = (
                 [n for n in stored_selection if n in table_names]

--- a/pages/automation.py
+++ b/pages/automation.py
@@ -97,6 +97,28 @@ def _guess_id_field(fields: list[str]) -> Optional[str]:
     return None
 
 
+_HYPOTHESIS_FIELD_HINTS = ("hypothesis",)
+
+
+def _guess_hypothesis_field(fields: list[str]) -> Optional[str]:
+    lowered = {f.lower(): f for f in fields}
+    for hint in _HYPOTHESIS_FIELD_HINTS:
+        if hint in lowered:
+            return lowered[hint]
+    return None
+
+
+_CUSTOM_CODE_FIELD_HINTS = ("custom code", "code")
+
+
+def _guess_custom_code_field(fields: list[str]) -> Optional[str]:
+    lowered = {f.lower(): f for f in fields}
+    for hint in _CUSTOM_CODE_FIELD_HINTS:
+        if hint in lowered:
+            return lowered[hint]
+    return None
+
+
 def _reset_automation_state():
     for key in list(st.session_state.keys()):
         if key.startswith("auto_") or key.startswith("autofetch_"):
@@ -169,6 +191,44 @@ def _render_stage_fetch():
                 key="autofetch_pretest_kpi",
             )
 
+        use_page_filter = st.toggle(
+            "Enable page filter",
+            value=False,
+            key="autofetch_pretest_use_filter",
+            help=(
+                "When enabled, only baseline users who visited a matching page "
+                "are included. Useful for scoping the baseline to a specific "
+                "section of the site — e.g. a product category or checkout flow."
+            ),
+        )
+        page_filter_type = None
+        page_filter_value = ""
+        if use_page_filter:
+            fc1, fc2 = st.columns([1, 2])
+            with fc1:
+                page_filter_type = cast(
+                    Literal["regex", "contains"],
+                    st.radio(
+                        "Filter type",
+                        options=["contains", "regex"],
+                        format_func=lambda x: "URL contains" if x == "contains" else "Regex pattern",
+                        horizontal=True,
+                        key="autofetch_pretest_filter_type",
+                    ),
+                )
+            with fc2:
+                page_filter_value = st.text_input(
+                    "Filter value",
+                    placeholder=".html  |  /products/  |  \\.html$",
+                    key="autofetch_pretest_filter_value",
+                    help=(
+                        "The string or pattern to match against page_location. "
+                        "Regex uses BigQuery REGEXP_CONTAINS syntax. Matching is case-sensitive."
+                    ),
+                )
+            if not page_filter_value:
+                st.warning("Enter a filter value or disable the page filter.")
+
         try:
             experiment_start = datetime.strptime(start_date, "%Y-%m-%d").date()
         except ValueError:
@@ -191,6 +251,8 @@ def _render_stage_fetch():
                 output_type="binomial",
                 output_shape="aggregate",
                 kpi_add_to_cart=(PRETEST_KPI_OPTIONS[kpi_choice] == "add_to_cart"),
+                page_filter_type=page_filter_type if page_filter_value else None,
+                page_filter_value=page_filter_value,
             )
             baseline_sql = build_baseline(baseline_params)
             render_sql_viewer(baseline_sql, key="auto_pretest_sql")
@@ -325,6 +387,7 @@ def _render_stage_fetch():
     if st.button("Continue to choose analysis method(s) →", type="primary"):
         st.session_state["auto_df_binomial"] = df_binomial
         st.session_state["auto_df_continuous"] = df_continuous
+        st.session_state["auto_exp_prefix"] = exp_prefix
 
         df_pretest = st.session_state.get("auto_pretest_result")
         st.session_state["auto_df_pretest"] = df_pretest
@@ -537,6 +600,18 @@ def _render_stage_configure():
     ]
     revenue_source = active_methods[0].lower() if active_methods else "frequentist"
     if len(active_methods) > 1:
+        # Frequentist/Bayesian default to checked whenever Binomial data was
+        # fetched (Streamlit's checkbox `value=` only applies once, on first
+        # render — see the checkboxes above), so this radio's options can
+        # silently change shape without the user touching either checkbox.
+        # If the active set changed since the last run, drop the stale
+        # session_state pick instead of carrying over a choice made for a
+        # different combination of methods (e.g. "Bayesian" picked back when
+        # Continuous wasn't active yet, silently kept once it is).
+        if st.session_state.get("auto_revenue_source_methods") != active_methods:
+            st.session_state.pop("auto_revenue_source_radio", None)
+            st.session_state["auto_revenue_source_methods"] = active_methods
+
         choice = st.radio(
             "Use for the shared 'effect on revenue' field:",
             options=active_methods,
@@ -544,6 +619,8 @@ def _render_stage_configure():
             key="auto_revenue_source_radio",
         )
         revenue_source = choice.lower()
+
+    st.info(f"💰 'Effect on revenue' will be sent from: **{revenue_source.capitalize()}**.")
 
     st.divider()
     col_back, col_next = st.columns(2)
@@ -623,8 +700,17 @@ def _render_stage_results():
     cont = results.get("continuous")
     pretest = results.get("pretest")
 
+    # Which method's effect_on_revenue actually feeds the shared Airtable
+    # field — decided back in Step 2 (see the radio there), surfaced again
+    # here per-method so it's never ambiguous which number is really used,
+    # even if the three methods' monetary estimates disagree substantially.
+    revenue_source = st.session_state.get("auto_revenue_source", "frequentist")
+
+    def _revenue_tag(method: str) -> str:
+        return " 💰 *(used for shared 'effect on revenue')*" if revenue_source == method else ""
+
     if freq:
-        st.markdown("### Frequentist")
+        st.markdown(f"### Frequentist{_revenue_tag('frequentist')}")
         c1, c2, c3 = st.columns(3)
         c1.metric("P-value", f"{freq['p_value']:.4f}")
         c2.metric("Significant?", "Yes" if freq["is_significant"] else "No")
@@ -639,7 +725,7 @@ def _render_stage_results():
         st.divider()
 
     if bayes:
-        st.markdown("### Bayesian")
+        st.markdown(f"### Bayesian{_revenue_tag('bayesian')}")
         c1, c2, c3 = st.columns(3)
         c1.metric("Probability to beat control", f"{bayes['probability_pct']:.1f}%")
         c2.metric("Probability to be best", f"{bayes['prob_being_best']:.1%}")
@@ -656,7 +742,7 @@ def _render_stage_results():
 
     if cont:
         mode_label = "RPV" if cont.get("mode", "rpv") == "rpv" else "RPT"
-        st.markdown(f"### Continuous ({mode_label})")
+        st.markdown(f"### Continuous ({mode_label}){_revenue_tag('continuous')}")
         c1, c2, c3 = st.columns(3)
         c1.metric("Test used", cont["test_name"])
         c2.metric("P-value", f"{cont['p_value']:.4f}")
@@ -684,7 +770,6 @@ def _render_stage_results():
 
     start_dt = st.session_state.get("start_date")
     end_dt = st.session_state.get("end_date")
-    revenue_source = st.session_state.get("auto_revenue_source", "frequentist")
     payload = build_airtable_payload(
         control, variation, freq, bayes, cont, revenue_source=revenue_source,
         start_date=str(start_dt) if start_dt else None,
@@ -694,7 +779,11 @@ def _render_stage_results():
     st.session_state["auto_payload"] = payload
 
     st.markdown("**Result summary**")
-    st.caption("Airtable field names are chosen in the next step, based on the base/table you send to.")
+    st.caption(
+        f"💰 'effect_on_revenue' below is sourced from **{revenue_source.capitalize()}** "
+        "— change the source in Step 2 if that's not what you expected. "
+        "Airtable field names are chosen in the next step, based on the base/table you send to."
+    )
     st.json(payload)
 
     col_back, col_next = st.columns(2)
@@ -712,6 +801,63 @@ def _render_stage_results():
 # Step 4 — AI conclusion (optional)
 # ---------------------------------------------------------------------------
 
+def _lookup_experiment_record() -> tuple[list[str], Optional[dict], str]:
+    """
+    Searches the configured default Airtable base/table (AIRTABLE_BASE_ID/
+    AIRTABLE_TABLE_NAME) for the record matching this experiment (Step 1's
+    exp_prefix, via the same id-field guess the Send step uses). Shared by
+    the Hypothesis gate (required, blocks generation) and the Custom Code
+    lookup (optional context for Gemini) so both reuse one round-trip.
+    Returns (table_field_names, matched_record_fields_or_None, message).
+    """
+    exp_prefix = st.session_state.get("auto_exp_prefix")
+    creds = get_credentials()
+    api_key, base_id, table_name = creds["api_key"], creds["base_id"], creds["table_name"]
+
+    if not (api_key and base_id and table_name):
+        return [], None, (
+            "Airtable isn't fully configured (AIRTABLE_API_KEY/BASE_ID/TABLE_NAME) — "
+            "can't look up the experiment record."
+        )
+    if not exp_prefix:
+        return [], None, "No experiment ID from Step 1 to look up."
+
+    tables_result = list_tables(api_key, base_id)
+    if not tables_result["ok"]:
+        return [], None, f"Couldn't load Airtable tables: {tables_result['error']}"
+
+    table = next(
+        (t for t in tables_result["tables"] if table_name in (t["id"], t["name"])),
+        None,
+    )
+    if table is None:
+        return [], None, f"Configured table '{table_name}' wasn't found in the base."
+
+    id_field = _guess_id_field(table["fields"])
+    if not id_field:
+        return table["fields"], None, "Couldn't find an ID field on the configured table."
+
+    search_result = search_records(base_id, table["id"], api_key, id_field, exp_prefix)
+    if not search_result["ok"]:
+        return table["fields"], None, f"Airtable lookup failed: {search_result['error']}"
+
+    matches = search_result["records"]
+    if not matches:
+        return table["fields"], None, f"No Airtable record found yet for experiment '{exp_prefix}'."
+
+    # Prefer a match that already has a Hypothesis filled in, if more than one
+    # record matched the search term — otherwise just take the first.
+    hypothesis_field = _guess_hypothesis_field(table["fields"])
+    if hypothesis_field:
+        with_hypothesis = next(
+            (r for r in matches if str(r["fields"].get(hypothesis_field, "")).strip()), None,
+        )
+        if with_hypothesis:
+            return table["fields"], with_hypothesis["fields"], f"Matched Airtable record for '{exp_prefix}'."
+
+    return table["fields"], matches[0]["fields"], f"Matched Airtable record for '{exp_prefix}'."
+
+
 def _render_stage_ai():
     payload = st.session_state.get("auto_payload")
     results = st.session_state.get("auto_results") or {}
@@ -726,6 +872,20 @@ def _render_stage_ai():
         "Entirely optional — skip straight to sending if you don't want one."
     )
 
+    table_fields, record_fields, lookup_message = _lookup_experiment_record()
+
+    hypothesis_field = _guess_hypothesis_field(table_fields) if table_fields else None
+    hypothesis_ok = bool(
+        record_fields is not None and hypothesis_field
+        and str(record_fields.get(hypothesis_field, "")).strip()
+    )
+
+    custom_code_field = _guess_custom_code_field(table_fields) if table_fields else None
+    custom_code = (
+        str(record_fields.get(custom_code_field, "")).strip()
+        if record_fields is not None and custom_code_field else ""
+    )
+
     ai_input = {
         "payload": payload,
         "conclusions": {
@@ -734,6 +894,10 @@ def _render_stage_ai():
             if result.get("conclusion")
         },
     }
+    if custom_code:
+        # Optional context, not gated on — helps Gemini interpret what was
+        # actually being tested (e.g. which element/variant the code touches).
+        ai_input["custom_code"] = custom_code
 
     with st.expander("Data that would be sent to Gemini", expanded=False):
         st.json(ai_input)
@@ -744,7 +908,16 @@ def _render_stage_ai():
             "to enable this step. You can still continue without an AI conclusion."
         )
     else:
-        if st.button("🤖 Generate AI conclusion", type="primary"):
+        if not hypothesis_ok:
+            st.warning(
+                f"{lookup_message} Document the Hypothesis in Airtable first — "
+                "an AI conclusion can't be generated without it."
+            )
+        generate_clicked = st.button(
+            "🤖 Generate AI conclusion", type="primary",
+            disabled=not hypothesis_ok, key="auto_generate_ai_btn",
+        )
+        if generate_clicked:
             with st.spinner("Asking Gemini…"):
                 result = gemini_client.generate_conclusion(ai_input)
             if result["ok"]:
@@ -902,7 +1075,14 @@ def _render_stage_send():
             table_names = [t["name"] for t in tables]
             names_key = f"airtable_table_names_{base_id}"
             stored_selection = st.session_state.get(names_key, [])
-            default_selection = [n for n in stored_selection if n in table_names] or table_names[:1]
+            experiment_tables = [n for n in table_names if n.lower() == "experiment"] or [
+                n for n in table_names if "experiment" in n.lower()
+            ]
+            default_selection = (
+                [n for n in stored_selection if n in table_names]
+                or experiment_tables
+                or table_names[:1]
+            )
             selected_names = st.multiselect(
                 "Tables — send this result to each one selected",
                 options=table_names,

--- a/utility/automation_engine.py
+++ b/utility/automation_engine.py
@@ -6,7 +6,6 @@ Kept separate from pages/automation.py so it stays testable without Streamlit.
 """
 from __future__ import annotations
 
-import json
 import math
 from dataclasses import dataclass
 from typing import Literal, Optional
@@ -49,21 +48,24 @@ FIELD_LABELS = {
     "description": "Description",
 }
 
-DEFAULT_FIELD_NAME_HINTS = {
-    "start_date": "start date",
-    "end_date": "end date",
-    "visitors_control": "visitors - control",
-    "visitors_variation": "visitors - variation",
-    "conversions_control": "conversions - control",
-    "conversions_variation": "conversions - variation",
-    "probability_pct": "probability (%)",
-    "p_value": "p-value",
-    "continuous_p_value": "p-value (continuous)",
-    "continuous_test_name": "test used (continuous)",
-    "effect_on_revenue": "effect on revenue",
-    "pretest_mde_table": "pre-test mde table",
-    "ai_conclusion": "ai conclusion",
-    "description": "description",
+# Each key maps to a list of candidate names, tried in order — covers common
+# English/Dutch naming variants since Airtable bases here aren't necessarily
+# English (e.g. "Startdatum" instead of "Start date").
+DEFAULT_FIELD_NAME_HINTS: dict[str, list[str]] = {
+    "start_date": ["start date", "startdate", "startdatum"],
+    "end_date": ["end date", "enddate", "einddatum"],
+    "visitors_control": ["visitors - control", "visitors control"],
+    "visitors_variation": ["visitors - variation", "visitors variation"],
+    "conversions_control": ["conversions - control", "conversions control"],
+    "conversions_variation": ["conversions - variation", "conversions variation"],
+    "probability_pct": ["probability (%)", "probability"],
+    "p_value": ["p-value"],
+    "continuous_p_value": ["p-value (continuous)"],
+    "continuous_test_name": ["test used (continuous)"],
+    "effect_on_revenue": ["effect on revenue", "effect op omzet"],
+    "pretest_mde_table": ["pre-test mde table"],
+    "ai_conclusion": ["ai conclusion"],
+    "description": ["description"],
 }
 
 _TAIL_MAP = {
@@ -315,6 +317,22 @@ def run_pretest_analysis(
     }
 
 
+def format_pretest_table(table: list[dict]) -> str:
+    """
+    Renders the pre-test MDE table as plain text, one line per week, instead
+    of json.dumps(...) — Airtable long-text fields don't render JSON or
+    markdown tables, so a JSON blob just shows up as raw markup in the field.
+    """
+    lines = []
+    for row in table:
+        size_key = next((k for k in row if k not in ("Week", "MDE")), None)
+        size_label = size_key.replace("_", " ").lower() if size_key else ""
+        size_val = row.get(size_key) if size_key else None
+        size_part = f"{size_val:,} {size_label}" if size_val is not None else ""
+        lines.append(f"Week {row['Week']}: {size_part} — MDE {row['MDE']:.2%}")
+    return "\n".join(lines)
+
+
 def build_airtable_payload(
     control: Optional[VariantData],
     variation: Optional[VariantData],
@@ -349,7 +367,7 @@ def build_airtable_payload(
         })
 
     if pretest_result:
-        fields["pretest_mde_table"] = json.dumps(pretest_result["table"])
+        fields["pretest_mde_table"] = format_pretest_table(pretest_result["table"])
 
     if ai_conclusion:
         fields["ai_conclusion"] = ai_conclusion
@@ -357,7 +375,10 @@ def build_airtable_payload(
     if frequentist_result:
         fields["p_value"] = round(frequentist_result["p_value"], 6)
     if bayesian_result:
-        fields["probability_pct"] = round(bayesian_result["probability_pct"], 2)
+        # Airtable's own Percent field format multiplies the stored value by
+        # 100 for display, so it expects a raw proportion (0-1) — sending the
+        # already-computed percentage (e.g. 83.42) makes Airtable show 8342%.
+        fields["probability_pct"] = round(bayesian_result["probability_pct"] / 100, 6)
     if continuous_result:
         fields["continuous_p_value"] = round(continuous_result["p_value"], 6)
         fields["continuous_test_name"] = continuous_result["test_name"]
@@ -387,18 +408,40 @@ def apply_field_map(payload: dict, field_map: dict) -> dict:
     }
 
 
+def _normalize_field_name(name: str) -> str:
+    return "".join(ch for ch in name.lower() if ch.isalnum())
+
+
 def best_match_field(internal_key: str, available_fields: list) -> Optional[str]:
     """
-    Case-insensitive exact match of internal_key's default hint (see
-    DEFAULT_FIELD_NAME_HINTS) against a table's real field names — used only
-    to auto-preselect a sensible default in the assignment UI. Returns None
-    if there's no hint or no match, leaving the choice to the user.
+    Matches internal_key's default hints (see DEFAULT_FIELD_NAME_HINTS)
+    against a table's real field names — used only to auto-preselect a
+    sensible default in the assignment UI. Returns None if there's no hint
+    or no match, leaving the choice to the user.
+
+    Tries, in order: case-insensitive exact match against any hint, then a
+    normalized (spaces/punctuation stripped) exact match, then a normalized
+    substring match — e.g. "start_date" matches a field named "Test start
+    date" or "Startdatum" even though neither is an exact hint.
     """
-    hint = DEFAULT_FIELD_NAME_HINTS.get(internal_key, "")
-    if not hint:
+    hints = DEFAULT_FIELD_NAME_HINTS.get(internal_key, [])
+    if not hints:
         return None
-    hint_lower = hint.lower()
-    for field in available_fields:
-        if field.lower() == hint_lower:
-            return field
+
+    lowered = {f.lower(): f for f in available_fields}
+    for hint in hints:
+        if hint.lower() in lowered:
+            return lowered[hint.lower()]
+
+    normalized_fields = {_normalize_field_name(f): f for f in available_fields}
+    for hint in hints:
+        norm_hint = _normalize_field_name(hint)
+        if norm_hint in normalized_fields:
+            return normalized_fields[norm_hint]
+
+    for hint in hints:
+        norm_hint = _normalize_field_name(hint)
+        for norm_field, original in normalized_fields.items():
+            if norm_hint in norm_field or norm_field in norm_hint:
+                return original
     return None

--- a/utility/gemini_client.py
+++ b/utility/gemini_client.py
@@ -19,14 +19,18 @@ _PROMPT_INSTRUCTIONS = """\
 You are a conversion-rate-optimization analyst reviewing the results of an
 A/B test. Below is a JSON object with the computed statistics (frequentist,
 Bayesian, and/or continuous-metric analysis, and an optional pre-test MDE
-projection) for a control ("Control") vs. a variation ("Variation").
+projection) for a control ("Control") vs. a variation ("Variation"). It may
+also include a "custom_code" field — the actual implementation code for the
+variation — use it only to understand what was really being tested, not as
+something to comment on directly.
 
-Write a short, plain-language conclusion (3-6 sentences) a stakeholder
-without a statistics background could act on. Cover:
+Write a short, plain-language conclusion (3-6 sentences), IN DUTCH, that a
+stakeholder without a statistics background could act on. Cover:
 - Whether the result is statistically significant / conclusive, and how confident to be.
 - The practical size of the effect (uplift, revenue impact) if available.
 - A clear recommendation: ship the variation, keep testing, or stop/iterate.
 Do not restate raw numbers already visible in the data verbatim; interpret them.
+Respond entirely in Dutch, including the recommendation.
 
 Data:
 """


### PR DESCRIPTION
## Summary
- Send Bayesian probability to Airtable as a raw proportion (0-1) instead of a pre-computed percentage, so Airtable's own Percent field formatting doesn't double-convert it (83.42 -> 8342%).
- Render the pre-test MDE table as plain text instead of a JSON blob, since Airtable long-text fields don't render JSON or markdown tables.
- Broaden Airtable field-name auto-matching (start/end date and others) with multiple hint variants (incl. Dutch) plus a normalized substring fallback.
- Gate AI conclusion generation on the linked Airtable record's Hypothesis field having a value, looked up via Step 1's experiment ID; also pull in an optional Custom Code field as extra context for Gemini.
- Write AI conclusions in Dutch.
- Add a regex/contains page filter to the pre-test baseline fetch.
- Pre-select a table named "experiment" by default in the Send step.
- Fix the 'effect on revenue' source selector: it no longer silently carries over a stale pick when the active method set changes, and both Step 2 and Step 3 now show explicitly which method's number is used — closing the gap where Bayesian's estimate could be sent even though Continuous was the intended source.

## Test plan
- Verified pretest table formatting, field-name matching (incl. Dutch variants), and the Bayesian proportion conversion with direct function calls
- Simulated the revenue-source stale-pick reset across a sequence of changing active-method configurations to confirm it no longer carries over a choice from an unrelated earlier configuration
- Traced RPV/RPT wiring end-to-end to confirm a single source of truth (no separate bug there)