### PR TITLE
Add event-based user filtering, alongside the existing page URL filter

### DIFF
--- a/pages/automation.py
+++ b/pages/automation.py
@@ -221,6 +221,7 @@ def _render_stage_fetch():
             render_sql_viewer(baseline_sql, key="auto_pretest_sql")
             render_execution_gate(
                 project, baseline_sql, result_key="auto_pretest_result", allow_preview=True,
+                dataset=dataset,
             )
 
     st.divider()
@@ -341,7 +342,9 @@ def _render_stage_fetch():
         )
         sql = build_experiment_single_output_sql(shared_scan_select, chain)
         render_sql_viewer(sql, key="auto_sql")
-        render_execution_gate(project, sql, result_key=f"auto_{label}_result", allow_preview=True)
+        render_execution_gate(
+            project, sql, result_key=f"auto_{label}_result", allow_preview=True, dataset=dataset,
+        )
 
     df_binomial = st.session_state.get("auto_binomial_result")
     df_continuous = st.session_state.get("auto_continuous_result")

--- a/pages/automation.py
+++ b/pages/automation.py
@@ -20,6 +20,7 @@ from utility.bq_ui_components import (
     render_connection_selectors,
     render_date_range,
     render_variant_inputs,
+    render_user_filter,
     render_execution_gate,
     render_combined_execution_gate,
     render_sql_viewer,
@@ -28,7 +29,7 @@ from utility.sql_builder import (
     BaselineParams,
     BinomialParams,
     ContinuousParams,
-    binomial_shared_scan_flags,
+    experiment_shared_scan_flags,
     build_baseline,
     build_shared_scan_select,
     build_binomial_from_shared_scan,
@@ -186,44 +187,6 @@ def _render_stage_fetch():
                 key="autofetch_pretest_kpi",
             )
 
-        use_page_filter = st.toggle(
-            "Enable page filter",
-            value=False,
-            key="autofetch_pretest_use_filter",
-            help=(
-                "When enabled, only baseline users who visited a matching page "
-                "are included. Useful for scoping the baseline to a specific "
-                "section of the site — e.g. a product category or checkout flow."
-            ),
-        )
-        page_filter_type = None
-        page_filter_value = ""
-        if use_page_filter:
-            fc1, fc2 = st.columns([1, 2])
-            with fc1:
-                page_filter_type = cast(
-                    Literal["regex", "contains"],
-                    st.radio(
-                        "Filter type",
-                        options=["contains", "regex"],
-                        format_func=lambda x: "URL contains" if x == "contains" else "Regex pattern",
-                        horizontal=True,
-                        key="autofetch_pretest_filter_type",
-                    ),
-                )
-            with fc2:
-                page_filter_value = st.text_input(
-                    "Filter value",
-                    placeholder=".html  |  /products/  |  \\.html$",
-                    key="autofetch_pretest_filter_value",
-                    help=(
-                        "The string or pattern to match against page_location. "
-                        "Regex uses BigQuery REGEXP_CONTAINS syntax. Matching is case-sensitive."
-                    ),
-                )
-            if not page_filter_value:
-                st.warning("Enter a filter value or disable the page filter.")
-
         try:
             experiment_start = datetime.strptime(start_date, "%Y-%m-%d").date()
         except ValueError:
@@ -238,6 +201,11 @@ def _render_stage_fetch():
                 f"({int(weeks_before)} full week(s), Monday-Sunday)."
             )
 
+            filter_type, filter_value = render_user_filter(
+                project, dataset, str(baseline_start), str(baseline_end),
+                key_prefix="autofetch_pretest",
+            )
+
             baseline_params = BaselineParams(
                 project=project,
                 dataset=dataset,
@@ -246,8 +214,8 @@ def _render_stage_fetch():
                 output_type="binomial",
                 output_shape="aggregate",
                 kpi_add_to_cart=(PRETEST_KPI_OPTIONS[kpi_choice] == "add_to_cart"),
-                page_filter_type=page_filter_type if page_filter_value else None,
-                page_filter_value=page_filter_value,
+                filter_type=filter_type,
+                filter_value=filter_value,
             )
             baseline_sql = build_baseline(baseline_params)
             render_sql_viewer(baseline_sql, key="auto_pretest_sql")
@@ -301,6 +269,11 @@ def _render_stage_fetch():
 
     match_strategy = cast(Literal["exact", "like"], match_strategy)
 
+    st.divider()
+    filter_type, filter_value = render_user_filter(
+        project, dataset, start_date, end_date, key_prefix="autofetch_exp",
+    )
+
     binomial_params: Optional[BinomialParams] = None
     if want_binomial:
         binomial_params = BinomialParams(
@@ -319,6 +292,8 @@ def _render_stage_fetch():
             kpi_device_split=False,
             kpi_login=False,
             kpi_create_account=False,
+            filter_type=filter_type,
+            filter_value=filter_value,
         )
 
     continuous_params: Optional[ContinuousParams] = None
@@ -334,9 +309,11 @@ def _render_stage_fetch():
             device_filter="all",
             query_mode="all_users",  # RPV — non-buyers included, matches run_continuous_analysis's per-visitor assumption
             post_exposure_filter=True,
+            filter_type=filter_type,
+            filter_value=filter_value,
         )
 
-    need_page_location, need_payment_type = binomial_shared_scan_flags(binomial_params)
+    need_page_location, need_payment_type = experiment_shared_scan_flags(binomial_params, continuous_params)
     shared_scan_select = build_shared_scan_select(
         project, dataset, start_date, end_date, param_key,
         need_page_location, need_payment_type,

--- a/pages/data_export.py
+++ b/pages/data_export.py
@@ -23,6 +23,7 @@ from utility.bq_ui_components import (
     render_date_range,
     render_variant_inputs,
     render_kpi_checkboxes,
+    render_user_filter,
     render_sql_viewer,
     render_export_options,
     render_combined_execution_gate,
@@ -39,7 +40,7 @@ from utility.sql_builder import (
     build_sequential,
     build_interaction,
     build_autodetect_variants_query,
-    binomial_shared_scan_flags,
+    experiment_shared_scan_flags,
     build_shared_scan_select,
     build_binomial_from_shared_scan,
     build_continuous_from_shared_scan,
@@ -139,55 +140,9 @@ def _render_baseline_inputs(
         )
 
     st.divider()
-    st.subheader("Page filter")
-    st.caption(
-        "Optional. Filter to users who visited specific pages before inclusion. "
-        "Leave disabled to include all users in the date range."
+    filter_type, filter_value = render_user_filter(
+        project, dataset, start_date, end_date, key_prefix="bl",
     )
-
-    use_filter = st.toggle(
-        "Enable page filter",
-        value=False,
-        key="bl_use_filter",
-        help=(
-            "When enabled, only users who visited a matching page during the date range "
-            "are included. Useful for scoping analysis to a specific section of the site — "
-            "for example, a product category or checkout flow."
-        ),
-    )
-    page_filter_type = None
-    page_filter_value = ""
-
-    if use_filter:
-        page_filter_type = cast(
-            Literal["regex", "contains"],
-            st.radio(
-                "Filter type",
-                options=["contains", "regex"],
-                format_func=lambda x: "URL contains" if x == "contains" else "Regex pattern",
-                horizontal=True,
-                key="bl_filter_type",
-                help=(
-                    "URL contains: simple substring match against the full page URL. "
-                    "Regex: BigQuery REGEXP_CONTAINS syntax for more specific patterns, "
-                    "e.g. r'\\.html$' to match only HTML product pages."
-                ),
-            ),
-        )
-        page_filter_value = st.text_input(
-            "Filter value",
-            placeholder=".html  |  /products/  |  \\.html$",
-            key="bl_filter_value",
-            help=(
-                "The string or pattern to match against page_location. "
-                "Contains example: '/products/shoes/'. "
-                "Regex example: r'/(product|category)/'. "
-                "Matching is case-sensitive."
-            ),
-        )
-        if not page_filter_value:
-            st.warning("Enter a filter value or disable the page filter.")
-            return None
 
     return BaselineParams(
         project=project,
@@ -197,8 +152,8 @@ def _render_baseline_inputs(
         output_type=output_type,
         output_shape=output_shape,
         kpi_add_to_cart=kpi_add_to_cart,
-        page_filter_type=page_filter_type,
-        page_filter_value=page_filter_value,
+        filter_type=filter_type,
+        filter_value=filter_value,
     )
 
 
@@ -257,6 +212,11 @@ def _render_experiment_inputs(
         key="exp_post_exposure",
     )
 
+    st.divider()
+    filter_type, filter_value = render_user_filter(
+        project, dataset, start_date, end_date, key_prefix="exp",
+    )
+
     binomial_params: Optional[BinomialParams] = None
     continuous_params: Optional[ContinuousParams] = None
 
@@ -283,6 +243,8 @@ def _render_experiment_inputs(
             kpi_device_split=kpis.get("kpi_device_split", True),
             kpi_login=kpis.get("kpi_login", False),
             kpi_create_account=kpis.get("kpi_create_account", False),
+            filter_type=filter_type,
+            filter_value=filter_value,
         )
 
     if want_continuous:
@@ -331,6 +293,8 @@ def _render_experiment_inputs(
             device_filter=device_filter,
             query_mode=query_mode,
             post_exposure_filter=post_exposure,
+            filter_type=filter_type,
+            filter_value=filter_value,
         )
 
     if not _experiments_valid(experiments):
@@ -746,7 +710,7 @@ def _run_experiment_mode(project: str, dataset: str, selected: dict) -> None:
     if ref is None:
         return  # _render_experiment_inputs already guards against this
 
-    need_page_location, need_payment_type = binomial_shared_scan_flags(bp)
+    need_page_location, need_payment_type = experiment_shared_scan_flags(bp, cp)
     shared_scan_select = build_shared_scan_select(
         ref.project, ref.dataset, ref.start_date, ref.end_date, ref.param_key,
         need_page_location, need_payment_type,

--- a/utility/bq_client.py
+++ b/utility/bq_client.py
@@ -566,6 +566,21 @@ def autodetect_kpis(
     return df["event_name"].tolist() if not df.empty else []
 
 
+def autodetect_event_names(
+    project: str,
+    dataset: str,
+    start_date: str,
+    end_date: str,
+    limit: int = 100,
+) -> list[str]:
+    """Distinct event names in the date range, most frequent first — lets the
+    event-filter UI offer a real pick-list instead of a blind free-text guess."""
+    from utility.sql_builder import build_autodetect_event_names_query
+    sql = build_autodetect_event_names_query(project, dataset, start_date, end_date, limit)
+    df = run_query(project, sql)
+    return df["event_name"].tolist() if not df.empty else []
+
+
 # ---------------------------------------------------------------------------
 # Export helpers
 # ---------------------------------------------------------------------------

--- a/utility/bq_client.py
+++ b/utility/bq_client.py
@@ -501,6 +501,26 @@ def run_preview(project: str, sql: str, limit: int = 25) -> "pd.DataFrame":
 # ---------------------------------------------------------------------------
 # Auto-detect helpers
 # ---------------------------------------------------------------------------
+# All three sample only a short recent window rather than the full (possibly
+# months-long) date range — what they're looking for (a variant string, a
+# known KPI event, a custom event name) is stable over the course of an
+# experiment, so scanning the whole range buys no extra accuracy, only extra
+# cost. Each shows the bytes it actually scanned via dry_run, since these are
+# real billable queries a user can click repeatedly without ever seeing a
+# "Run full query"-style cost prompt otherwise.
+
+def _sample_recent_window(start_date: str, end_date: str, days: int) -> tuple[str, str]:
+    """Clamps to the last `days` day(s) ending at end_date, staying within
+    [start_date, end_date]. The full range is left untouched for the actual
+    export query — only auto-detect probes use this narrower window."""
+    from datetime import datetime, timedelta
+    end_dt = datetime.strptime(end_date, "%Y-%m-%d")
+    start_dt = max(
+        end_dt - timedelta(days=days),
+        datetime.strptime(start_date, "%Y-%m-%d"),
+    )
+    return start_dt.strftime("%Y-%m-%d"), end_date
+
 
 def autodetect_variants(
     project: str,
@@ -510,20 +530,10 @@ def autodetect_variants(
     param_key: str,
     prefix: str,
 ) -> list[str]:
+    from datetime import datetime
     from utility.sql_builder import build_autodetect_variants_query
-    from datetime import datetime, timedelta
 
-    # Use only the last day of the selected date range to minimise scan cost.
-    # Variant strings are stable — they don't change over the course of an experiment —
-    # so a 1-day window is sufficient to discover all variants.
-    # The full date range is preserved for the actual export query.
-    end_dt   = datetime.strptime(end_date, "%Y-%m-%d")
-    start_dt = max(
-        end_dt - timedelta(days=1),
-        datetime.strptime(start_date, "%Y-%m-%d"),
-    )
-    sample_start = start_dt.strftime("%Y-%m-%d")
-    sample_end   = end_date  # end stays the same
+    sample_start, sample_end = _sample_recent_window(start_date, end_date, days=1)
 
     sql = build_autodetect_variants_query(
         project, dataset, sample_start, sample_end, param_key, prefix
@@ -536,6 +546,7 @@ def autodetect_variants(
     )
     df = run_query(project, sql)
     if df.empty:
+        end_dt = datetime.strptime(end_date, "%Y-%m-%d")
         if end_dt.date() >= datetime.now().date():
             st.warning(
                 f"No variant strings found on {sample_start} → {sample_end}. "
@@ -561,7 +572,16 @@ def autodetect_kpis(
     end_date: str,
 ) -> list[str]:
     from utility.sql_builder import build_autodetect_kpi_query
-    sql = build_autodetect_kpi_query(project, dataset, start_date, end_date)
+
+    sample_start, sample_end = _sample_recent_window(start_date, end_date, days=2)
+
+    sql = build_autodetect_kpi_query(project, dataset, sample_start, sample_end)
+    cost = dry_run(project, sql)
+    st.caption(
+        f"Auto-detect scanned the last 2 days of your date range "
+        f"({sample_start} → {sample_end}): "
+        f"**{cost['display']}** — separate from your export query cost."
+    )
     df = run_query(project, sql)
     return df["event_name"].tolist() if not df.empty else []
 
@@ -573,10 +593,26 @@ def autodetect_event_names(
     end_date: str,
     limit: int = 100,
 ) -> list[str]:
-    """Distinct event names in the date range, most frequent first — lets the
-    event-filter UI offer a real pick-list instead of a blind free-text guess."""
+    """
+    Distinct event names, most frequent first — lets the event-filter UI
+    offer a real pick-list instead of a blind free-text guess. Sampled over
+    the last 2 days rather than the full date range: which event names exist
+    at all doesn't meaningfully change day to day, and event_name is scanned
+    across every row in range regardless of how narrow the actual condition
+    ends up being, so this is the one auto-detect query size scales with
+    range length the most.
+    """
     from utility.sql_builder import build_autodetect_event_names_query
-    sql = build_autodetect_event_names_query(project, dataset, start_date, end_date, limit)
+
+    sample_start, sample_end = _sample_recent_window(start_date, end_date, days=2)
+
+    sql = build_autodetect_event_names_query(project, dataset, sample_start, sample_end, limit)
+    cost = dry_run(project, sql)
+    st.caption(
+        f"Auto-detect scanned the last 2 days of your date range "
+        f"({sample_start} → {sample_end}): "
+        f"**{cost['display']}** — separate from your export query cost."
+    )
     df = run_query(project, sql)
     return df["event_name"].tolist() if not df.empty else []
 

--- a/utility/bq_ui_components.py
+++ b/utility/bq_ui_components.py
@@ -11,7 +11,8 @@ from utility.bq_client import (
     is_authenticated, get_auth_url, exchange_code_for_credentials,
     get_redirect_uri, sign_out, list_projects, list_datasets, dry_run,
     get_monthly_usage, run_preview, run_query, run_combined_export,
-    df_to_csv_bytes, export_to_sheets, autodetect_variants, autodetect_kpis
+    df_to_csv_bytes, export_to_sheets, autodetect_variants, autodetect_kpis,
+    autodetect_event_names,
 )
 from utility.sql_builder import VariantPair, ExperimentConfig
 
@@ -475,6 +476,109 @@ def render_kpi_checkboxes(
         )
 
     return kpis
+
+
+# ---------------------------------------------------------------------------
+# User filter (page URL or event) — scopes the population
+# ---------------------------------------------------------------------------
+
+def render_user_filter(
+    project: Optional[str],
+    dataset: Optional[str],
+    start_date: str,
+    end_date: str,
+    key_prefix: str,
+) -> tuple[Optional[Literal["contains", "regex", "event"]], str]:
+    """
+    Renders the optional "scope to a subset of users" block, shared by every
+    fetch flow that wants to restrict its population to users who did
+    something specific during the date range — either visited a matching
+    page (URL contains/regex against page_view's page_location) or fired a
+    specific event at least once (exact event_name match). Event mode is
+    more robust than a URL match whenever the URL itself can't differentiate
+    page types (e.g. everything lives behind one route, or a page type is
+    only knowable from an event a click handler fires).
+
+    Returns (filter_type, filter_value) — filter_type is None when disabled
+    or when enabled but left without a value (a warning is shown either way).
+    """
+    st.subheader("User filter")
+    st.caption(
+        "Optional. Scope the population to users who visited a matching page, "
+        "or fired a specific event, at any point during the date range."
+    )
+
+    enabled = st.toggle("Enable user filter", value=False, key=f"{key_prefix}_filter_enabled")
+    if not enabled:
+        return None, ""
+
+    filter_type = cast(
+        Literal["contains", "regex", "event"],
+        st.radio(
+            "Filter by",
+            options=["contains", "regex", "event"],
+            format_func=lambda x: (
+                "Page URL — contains" if x == "contains"
+                else "Page URL — regex" if x == "regex"
+                else "Event"
+            ),
+            horizontal=True,
+            key=f"{key_prefix}_filter_type",
+            help=(
+                "Page URL: matches page_view's page_location — works well when the "
+                "site's URL structure differentiates page types. Event: matches users "
+                "who fired a specific event at least once — more robust when the URL "
+                "can't tell page types apart."
+            ),
+        ),
+    )
+
+    if filter_type == "event":
+        autodetect_key = f"{key_prefix}_filter_detected_events"
+        if st.button(
+            "🔍 Discover event names",
+            disabled=not project or not dataset,
+            key=f"{key_prefix}_filter_autodetect_btn",
+        ):
+            if project and dataset:  # narrows Optional[str] → str for type checker
+                with st.spinner("Scanning for distinct event names…"):
+                    st.session_state[autodetect_key] = autodetect_event_names(
+                        project, dataset, start_date, end_date,
+                    )
+
+        detected = st.session_state.get(autodetect_key, [])
+        if detected:
+            filter_value = cast(str, st.selectbox(
+                "Event name",
+                options=detected,
+                key=f"{key_prefix}_filter_event_select",
+                help="Users who fired this event at least once during the date range are included.",
+            ))
+        else:
+            st.caption("ℹ️ Click 'Discover event names' above, or type one in manually below.")
+            filter_value = st.text_input(
+                "Event name",
+                placeholder="e.g. view_item, sign_up, video_start",
+                key=f"{key_prefix}_filter_event_value",
+                help="Must exactly match a GA4 event_name value. Case-sensitive.",
+            )
+    else:
+        filter_value = st.text_input(
+            "Filter value",
+            placeholder=".html  |  /products/  |  \\.html$",
+            key=f"{key_prefix}_filter_page_value",
+            help=(
+                "The string or pattern to match against page_location. "
+                "Contains example: '/products/shoes/'. "
+                "Regex example: '/(product|category)/'. Matching is case-sensitive."
+            ),
+        )
+
+    if not filter_value.strip():
+        st.warning("Enter a filter value (or event name) above, or disable the filter.")
+        return None, ""
+
+    return filter_type, filter_value.strip()
 
 
 # ---------------------------------------------------------------------------

--- a/utility/bq_ui_components.py
+++ b/utility/bq_ui_components.py
@@ -590,9 +590,14 @@ def render_execution_gate(
     sql: str,
     result_key: str = "query_result",
     allow_preview: bool = True,
+    dataset: Optional[str] = None,
 ):
     """
-    Always runs dry-run and shows bytes.
+    Always runs dry-run and shows bytes. When `dataset` is given, also shows
+    this project's monthly usage against the 1 TB/month free tier — a single
+    query's own scan can look negligible in isolation while still adding to a
+    budget that's already mostly spent from earlier runs this month, which a
+    per-query estimate alone won't surface.
     Offers optional preview (25 rows).
     Shows confirm button to run full query.
     """
@@ -606,11 +611,56 @@ def render_execution_gate(
         st.error(f"Dry-run failed: {cost['error']}")
         return
 
-    col1, col2 = st.columns(2)
+    usage: Optional[dict] = None
+    if dataset:
+        with st.spinner("Fetching monthly usage…"):
+            usage = get_monthly_usage(project, dataset)
+
+    col1, col2, col3 = st.columns(3)
     with col1:
-        st.metric("Estimated scan", cost["display"])
+        st.metric(
+            "This query", cost["display"],
+            help="Estimated bytes scanned by this query (BigQuery dry-run).",
+        )
     with col2:
-        st.metric("Free tier usage", f"{cost['free_tier_pct']}%", help="Based on 1 TB/month free tier")
+        if usage is not None:
+            st.metric(
+                "Used this month",
+                usage["used_display"] if not usage["error"] else "Unavailable",
+                help=(
+                    "Bytes processed by all queries in this project since the 1st of "
+                    "the month. Sourced from INFORMATION_SCHEMA.JOBS_BY_PROJECT. "
+                    "Cached for 5 minutes."
+                ),
+            )
+        else:
+            st.metric("Free tier usage", f"{cost['free_tier_pct']}%", help="Based on 1 TB/month free tier")
+    with col3:
+        if usage is not None:
+            st.metric(
+                "Remaining free tier",
+                usage["remaining_display"] if not usage["error"] else "Unavailable",
+            )
+
+    if usage is not None and not usage["error"]:
+        used_pct = usage["used_pct"] / 100  # st.progress expects 0.0-1.0
+        st.progress(
+            min(used_pct, 1.0),
+            text=f"{usage['used_display']} of 1 TB used this month ({usage['used_pct']}%)",
+        )
+        if usage["remaining_bytes"] > 0:
+            query_pct_of_remaining = round((cost["bytes"] / usage["remaining_bytes"]) * 100, 3)
+            st.caption(
+                f"This query consumes **{query_pct_of_remaining}%** "
+                f"of your remaining {usage['remaining_display']} budget."
+            )
+    elif usage is not None and usage.get("permission_denied"):
+        st.caption(
+            "ℹ️ Monthly usage unavailable — "
+            "the authenticated account needs `bigquery.jobs.list` at project level."
+        )
+    elif usage is not None:
+        st.caption(f"ℹ️ Monthly usage unavailable: {usage['error']}")
 
     if allow_preview:
         if st.button("👁️ Preview (25 rows)", key=f"{result_key}_preview_btn"):

--- a/utility/sql_builder.py
+++ b/utility/sql_builder.py
@@ -54,8 +54,12 @@ class BaselineParams:
     # Adds add-to-cart conversion counts alongside the purchase-based ones.
     # Binomial only — revenue mode has no "conversion" concept to extend.
     kpi_add_to_cart: bool = False
-    page_filter_type: Optional[Literal["regex", "contains"]] = None  # None = no filter
-    page_filter_value: str = ""
+    # "contains"/"regex" scope to users who visited a matching page_view URL;
+    # "event" scopes to users who fired a specific event at least once during
+    # the date range — more robust than a URL match whenever the URL itself
+    # can't differentiate page types. None = no filter.
+    filter_type: Optional[Literal["contains", "regex", "event"]] = None
+    filter_value: str = ""
 
 
 @dataclass
@@ -77,6 +81,11 @@ class BinomialParams:
     # KPI toggles — cost-warning group (adds page_view scan)
     kpi_login: bool = False
     kpi_create_account: bool = False
+    # Same semantics as BaselineParams.filter_type/filter_value — scopes the
+    # experiment population to users who visited a matching page or fired a
+    # specific event, at any point in the date range.
+    filter_type: Optional[Literal["contains", "regex", "event"]] = None
+    filter_value: str = ""
 
 
 @dataclass
@@ -91,6 +100,8 @@ class ContinuousParams:
     device_filter: Literal["all", "desktop", "mobile"] = "all"
     query_mode: Literal["all_users", "revenue_only"] = "all_users"
     post_exposure_filter: bool = True
+    filter_type: Optional[Literal["contains", "regex", "event"]] = None
+    filter_value: str = ""
 
 
 @dataclass
@@ -129,16 +140,31 @@ class InteractionParams:
 # BASELINE
 # ---------------------------------------------------------------------------
 
-def _baseline_page_filter(p: BaselineParams, table: str, suffix: str) -> tuple[str, str]:
-    """Builds the optional page-view filter CTE + join clause shared by all baseline shapes."""
-    if not (p.page_filter_type and p.page_filter_value):
+def _baseline_user_filter(p: BaselineParams, table: str, suffix: str) -> tuple[str, str]:
+    """
+    Builds the optional user-filter CTE + join clause shared by all baseline
+    shapes. "contains"/"regex" scope to users who visited a matching
+    page_view URL; "event" scopes to users who fired a specific event at
+    least once during the date range — more robust than a URL match whenever
+    the URL itself can't differentiate page types.
+    """
+    if not (p.filter_type and p.filter_value):
         return "", ""
-    if p.page_filter_type == "regex":
-        page_condition = f"AND REGEXP_CONTAINS(params.value.string_value, r'{p.page_filter_value}')"
+    if p.filter_type == "event":
+        cte = f"""
+filtered_users AS (
+  SELECT DISTINCT user_pseudo_id
+  FROM {table}
+  WHERE {suffix}
+    AND event_name = '{p.filter_value}'
+),"""
     else:
-        page_condition = f"AND params.value.string_value LIKE '%{p.page_filter_value}%'"
-    cte = f"""
-view_page_users AS (
+        if p.filter_type == "regex":
+            page_condition = f"AND REGEXP_CONTAINS(params.value.string_value, r'{p.filter_value}')"
+        else:
+            page_condition = f"AND params.value.string_value LIKE '%{p.filter_value}%'"
+        cte = f"""
+filtered_users AS (
   SELECT DISTINCT user_pseudo_id
   FROM {table}, UNNEST(event_params) AS params
   WHERE {suffix}
@@ -146,7 +172,7 @@ view_page_users AS (
     AND params.key = 'page_location'
     {page_condition}
 ),"""
-    join = "INNER JOIN view_page_users ON main.user_pseudo_id = view_page_users.user_pseudo_id"
+    join = "INNER JOIN filtered_users ON main.user_pseudo_id = filtered_users.user_pseudo_id"
     return cte, join
 
 
@@ -161,7 +187,7 @@ def build_baseline(p: BaselineParams, limit: int = 0) -> str:
 def _build_baseline_aggregate(p: BaselineParams, limit: int = 0) -> str:
     table = _table_ref(p.project, p.dataset)
     suffix = _suffix_filter(p.start_date, p.end_date)
-    view_page_cte, join_clause = _baseline_page_filter(p, table, suffix)
+    user_filter_cte, join_clause = _baseline_user_filter(p, table, suffix)
     limit_clause = f"\nLIMIT {limit}" if limit else ""
 
     if p.output_type == "revenue":
@@ -206,7 +232,7 @@ def _build_baseline_aggregate(p: BaselineParams, limit: int = 0) -> str:
 DECLARE start_date STRING DEFAULT '{p.start_date}';
 DECLARE end_date   STRING DEFAULT '{p.end_date}';
 
-WITH{view_page_cte}
+WITH{user_filter_cte}
 dummy AS (SELECT 1)  -- placeholder when no page filter
 
 SELECT{select_cols}
@@ -219,7 +245,7 @@ WHERE main.{suffix}{limit_clause};
 def _build_baseline_daily(p: BaselineParams, limit: int = 0) -> str:
     table = _table_ref(p.project, p.dataset)
     suffix = _suffix_filter(p.start_date, p.end_date)
-    view_page_cte, join_clause = _baseline_page_filter(p, table, suffix)
+    user_filter_cte, join_clause = _baseline_user_filter(p, table, suffix)
     limit_clause = f"\nLIMIT {limit}" if limit else ""
 
     if p.output_type == "revenue":
@@ -241,7 +267,7 @@ def _build_baseline_daily(p: BaselineParams, limit: int = 0) -> str:
 DECLARE start_date STRING DEFAULT '{p.start_date}';
 DECLARE end_date   STRING DEFAULT '{p.end_date}';
 
-WITH{view_page_cte}
+WITH{user_filter_cte}
 dummy AS (SELECT 1)  -- placeholder when no page filter
 
 SELECT{select_cols}
@@ -259,14 +285,14 @@ def _build_baseline_per_user(p: BaselineParams, limit: int = 0) -> str:
     Revenue-only: a binomial baseline has no per-order raw value to fit."""
     table = _table_ref(p.project, p.dataset)
     suffix = _suffix_filter(p.start_date, p.end_date)
-    view_page_cte, join_clause = _baseline_page_filter(p, table, suffix)
+    user_filter_cte, join_clause = _baseline_user_filter(p, table, suffix)
     limit_clause = f"\nLIMIT {limit}" if limit else ""
 
     return f"""-- Baseline export (revenue, per-order raw values) — sample size preparation
 DECLARE start_date STRING DEFAULT '{p.start_date}';
 DECLARE end_date   STRING DEFAULT '{p.end_date}';
 
-WITH{view_page_cte}
+WITH{user_filter_cte}
 dummy AS (SELECT 1)  -- placeholder when no page filter
 
 SELECT
@@ -763,16 +789,25 @@ ORDER BY ed.purchase_revenue DESC{limit_clause};
 # session-scoped TEMP TABLE (both outputs, two queries against one scan) —
 # these functions don't know or care which.
 
-def binomial_shared_scan_flags(p: Optional[BinomialParams]) -> tuple[bool, bool]:
+def experiment_shared_scan_flags(
+    bp: Optional[BinomialParams], cp: Optional[ContinuousParams] = None,
+) -> tuple[bool, bool]:
     """
     Returns (need_page_location, need_payment_type) — the extra columns
-    build_binomial_from_shared_scan needs for its cost-warning KPIs
-    (login/create-account use page_location, iDEAL uses payment_type).
-    Continuous has no equivalent KPIs, so this only depends on binomial.
+    build_binomial_from_shared_scan / build_continuous_from_shared_scan need
+    for binomial's cost-warning KPIs (login/create-account use page_location,
+    iDEAL uses payment_type) and/or a "contains"/"regex" user filter on
+    either params (an "event" filter needs no extra column — event_name is
+    already always selected in shared_scan).
     """
-    if p is None:
-        return (False, False)
-    return (p.kpi_login or p.kpi_create_account, p.kpi_ideal)
+    need_page_location = False
+    need_payment_type = False
+    if bp is not None:
+        need_page_location = need_page_location or bp.kpi_login or bp.kpi_create_account or bp.filter_type in ("contains", "regex")
+        need_payment_type = need_payment_type or bp.kpi_ideal
+    if cp is not None:
+        need_page_location = need_page_location or cp.filter_type in ("contains", "regex")
+    return need_page_location, need_payment_type
 
 
 def build_shared_scan_select(
@@ -824,6 +859,32 @@ def build_shared_scan_select(
   FROM {table}
   WHERE {suffix}
     AND user_pseudo_id IS NOT NULL"""
+
+
+def _shared_scan_user_filter(filter_type: Optional[str], filter_value: str) -> str:
+    """
+    Optional filtered_users CTE, sourced from shared_scan rather than a fresh
+    table scan — shared_scan already carries every event row (incl.
+    event_name) in the date range, so an "event" filter is free; a
+    "contains"/"regex" filter needs shared_scan's optional page_location
+    column (see experiment_shared_scan_flags). Returns "" when disabled, and
+    the CTE body WITHOUT a trailing comma or trailing newline — callers splice
+    it into their own CTE chain and add a comma only if something follows it.
+    """
+    if not (filter_type and filter_value):
+        return ""
+    if filter_type == "event":
+        condition = f"event_name = '{filter_value}'"
+    elif filter_type == "regex":
+        condition = f"REGEXP_CONTAINS(page_location, r'{filter_value}')"
+    else:
+        condition = f"page_location LIKE '%{filter_value}%'"
+    return f"""
+filtered_users AS (
+  SELECT DISTINCT user_pseudo_id
+  FROM shared_scan
+  WHERE {condition}
+)"""
 
 
 def build_binomial_from_shared_scan(p: BinomialParams) -> str:
@@ -1086,12 +1147,19 @@ ideal_users AS (
 
     select_block = ",\n".join(select_cols)
 
-    return f"""{exposure_ctes}{ecommerce_cte}{device_cte}{optional_ctes}
+    filter_cte = _shared_scan_user_filter(p.filter_type, p.filter_value)
+    filter_cte_block = f"{filter_cte},\n" if filter_cte else ""
+    filter_join = (
+        "  INNER JOIN filtered_users fu ON vd.variant_user_pseudo_id = fu.user_pseudo_id\n"
+        if filter_cte else ""
+    )
+
+    return f"""{exposure_ctes}{ecommerce_cte}{device_cte}{optional_ctes}{filter_cte_block}
 final_data AS (
   SELECT
 {final_select}
   FROM variant_data vd
-{ecommerce_join}{device_join}{optional_joins}  WHERE vd.experience_variant_label != 'Other'
+{ecommerce_join}{device_join}{optional_joins}{filter_join}  WHERE vd.experience_variant_label != 'Other'
 )
 
 SELECT
@@ -1125,6 +1193,13 @@ def build_continuous_from_shared_scan(p: ContinuousParams) -> str:
     case_block = "\n".join(case_lines)
 
     join_type = "INNER JOIN" if p.query_mode == "revenue_only" else "LEFT JOIN"
+
+    filter_cte = _shared_scan_user_filter(p.filter_type, p.filter_value)
+    ecommerce_trailer = f",\n{filter_cte}\n" if filter_cte else "\n"
+    filter_join = (
+        "INNER JOIN filtered_users fu ON vd.user_pseudo_id = fu.user_pseudo_id\n"
+        if filter_cte else ""
+    )
 
     return f"""
 user_initial_exposure AS (
@@ -1175,8 +1250,7 @@ ecommerce_data AS (
     AND purchase_revenue IS NOT NULL
     AND purchase_revenue <> 0.0
   GROUP BY user_pseudo_id, transaction_id
-)
-
+){ecommerce_trailer}
 SELECT
   vd.user_pseudo_id        AS variant_user_pseudo_id,
   vd.experience_variant_label,
@@ -1186,7 +1260,7 @@ SELECT
 FROM variant_data vd
 {join_type} ecommerce_data ed ON vd.user_pseudo_id = ed.user_pseudo_id
 INNER JOIN device_data      dd ON vd.user_pseudo_id = dd.device_user_pseudo_id
-WHERE ('{p.device_filter}' = 'all' OR dd.primary_device = '{p.device_filter}')
+{filter_join}WHERE ('{p.device_filter}' = 'all' OR dd.primary_device = '{p.device_filter}')
 ORDER BY ed.purchase_revenue DESC"""
 
 
@@ -1546,6 +1620,32 @@ WHERE {suffix}
   AND params.value.string_value IS NOT NULL
 ORDER BY variant_string
 LIMIT 500;
+"""
+
+
+def build_autodetect_event_names_query(
+    project: str,
+    dataset: str,
+    start_date: str,
+    end_date: str,
+    limit: int = 100,
+) -> str:
+    """
+    Distinct event_name values in the date range, most frequent first — used
+    to let the user pick an event to filter users on, rather than guessing a
+    name blind. event_name is a flat top-level column (not a nested
+    event_params entry), so this is a cheap scan regardless of range length —
+    unlike autodetect_variants, no need to sample just the last day.
+    """
+    table = _table_ref(project, dataset)
+    suffix = _suffix_filter(start_date, end_date)
+    return f"""
+SELECT event_name, COUNT(*) AS event_count
+FROM {table}
+WHERE {suffix}
+GROUP BY event_name
+ORDER BY event_count DESC
+LIMIT {limit};
 """
 
 

--- a/utility/sql_builder.py
+++ b/utility/sql_builder.py
@@ -233,7 +233,7 @@ DECLARE start_date STRING DEFAULT '{p.start_date}';
 DECLARE end_date   STRING DEFAULT '{p.end_date}';
 
 WITH{user_filter_cte}
-dummy AS (SELECT 1)  -- placeholder when no page filter
+dummy AS (SELECT 1)  -- placeholder when no user filter
 
 SELECT{select_cols}
 FROM {table} AS main
@@ -268,7 +268,7 @@ DECLARE start_date STRING DEFAULT '{p.start_date}';
 DECLARE end_date   STRING DEFAULT '{p.end_date}';
 
 WITH{user_filter_cte}
-dummy AS (SELECT 1)  -- placeholder when no page filter
+dummy AS (SELECT 1)  -- placeholder when no user filter
 
 SELECT{select_cols}
 FROM {table} AS main
@@ -293,7 +293,7 @@ DECLARE start_date STRING DEFAULT '{p.start_date}';
 DECLARE end_date   STRING DEFAULT '{p.end_date}';
 
 WITH{user_filter_cte}
-dummy AS (SELECT 1)  -- placeholder when no page filter
+dummy AS (SELECT 1)  -- placeholder when no user filter
 
 SELECT
   main.user_pseudo_id AS user_pseudo_id,


### PR DESCRIPTION
## Summary
Every population filter in Baseline/pre-test and Experiment (Binomial/Continuous) exports previously had to be expressed as a page_location URL match. Many sites can't differentiate page types by URL alone (SPAs, app shells, or page types only knowable from an event a click handler fires), so this adds "Event" as a second filter mode: scope the population to users who fired a specific event at least once during the date range, alongside the existing "Page URL - contains/regex" modes.

- New shared `render_user_filter()` component (bq_ui_components.py) replaces the bespoke page-filter UI duplicated in data_export.py's Baseline mode and automation.py's pre-test baseline fetch, and adds the same capability — previously entirely absent — to the Experiment/main-fetch queries in both files.
- Event mode includes a "Discover event names" lookup (ordered by frequency) so users pick a real event name from the data instead of guessing blind.
- `BaselineParams.page_filter_type/page_filter_value` generalized to `filter_type/filter_value` (adds "event" alongside "contains"/"regex"). `BinomialParams`/`ContinuousParams` gain the same fields.
- For the shared-scan experiment queries, the filter is computed directly from `shared_scan` via a new `filtered_users` CTE — an "event" filter needs no extra scanned column at all, since `event_name` is already always selected; a page filter needs the existing optional `page_location` column.
- `binomial_shared_scan_flags` renamed to `experiment_shared_scan_flags(bp, cp)` since `page_location` may now be needed by either params, not just binomial's cost-warning KPIs.

## Test plan
- Direct SQL-generation checks for Baseline (no filter / contains / event) and both shared-scan builders (Binomial event filter, Continuous page filter) — verified correct CTE/comma placement and JOIN wiring
- `experiment_shared_scan_flags` verified to correctly resolve `page_location` need from either param's filter type
- AppTest end-to-end: data_export.py Baseline and Experiment modes — toggle filter → switch to Event → discover → select populates from a mocked event list
- AppTest end-to-end: automation.py Step 1 — same flow, plus confirmed the actual rendered SQL includes the `filtered_users` CTE with the entered event name