### PR TITLE
Surface each method's monetary conclusion, with pros/cons, to UI and …

### DIFF
--- a/pages/automation.py
+++ b/pages/automation.py
@@ -42,6 +42,8 @@ from utility.automation_engine import (
     VariantData,
     TAILS,
     FIELD_LABELS,
+    MONETARY_METHOD_NOTES,
+    MONETARY_METHOD_GUIDANCE,
     run_frequentist_analysis,
     run_bayesian_analysis,
     run_continuous_analysis,
@@ -684,6 +686,22 @@ def _render_stage_results():
     def _revenue_tag(method: str) -> str:
         return " 💰 *(used for shared 'effect on revenue')*" if revenue_source == method else ""
 
+    def _render_monetary_notes(method: str):
+        notes = MONETARY_METHOD_NOTES.get(method)
+        if not notes:
+            return
+        with st.expander(f"Pros & cons of {method.capitalize()}'s monetary estimate"):
+            st.markdown("**Pros**")
+            for point in notes["pros"]:
+                st.markdown(f"- {point}")
+            st.markdown("**Cons**")
+            for point in notes["cons"]:
+                st.markdown(f"- {point}")
+
+    active_monetary_methods = [m for m in ("frequentist", "bayesian", "continuous") if results.get(m)]
+    if len(active_monetary_methods) > 1:
+        st.info(f"💡 {MONETARY_METHOD_GUIDANCE}", icon="💡")
+
     if freq:
         st.markdown(f"### Frequentist{_revenue_tag('frequentist')}")
         c1, c2, c3 = st.columns(3)
@@ -697,6 +715,9 @@ def _render_stage_results():
             help=f"CI: {_fmt_money(ci_low)} to {_fmt_money(ci_high)}",
         )
         st.caption(freq["conclusion"])
+        if freq.get("monetary_conclusion"):
+            st.caption(freq["monetary_conclusion"])
+        _render_monetary_notes("frequentist")
         st.divider()
 
     if bayes:
@@ -713,6 +734,9 @@ def _render_stage_results():
             ),
         )
         st.caption(bayes["conclusion"])
+        if bayes.get("monetary_conclusion"):
+            st.caption(bayes["monetary_conclusion"])
+        _render_monetary_notes("bayesian")
         st.divider()
 
     if cont:
@@ -729,6 +753,9 @@ def _render_stage_results():
             help=f"CI: {_fmt_money(ci_low)} to {_fmt_money(ci_high)}",
         )
         st.caption(cont["conclusion"])
+        if cont.get("monetary_conclusion"):
+            st.caption(cont["monetary_conclusion"])
+        _render_monetary_notes("continuous")
         st.divider()
 
     if pretest:
@@ -863,12 +890,35 @@ def _render_stage_ai():
 
     ai_input = {
         "payload": payload,
+        # Each method's own written-output methods: "conclusion" is the
+        # statistical read (significance only); "monetary_conclusion" (where
+        # available) is the money-framed narrative — handles one-sided CI
+        # wording, non-significant hedging, and Bayesian's risk/reward
+        # framing correctly, which payload's bare numeric fields don't.
         "conclusions": {
-            method: result["conclusion"]
+            method: {
+                key: result[key]
+                for key in ("conclusion", "monetary_conclusion")
+                if result.get(key)
+            }
             for method, result in results.items()
-            if result.get("conclusion")
+            if result.get("conclusion") or result.get("monetary_conclusion")
         },
     }
+    active_monetary_methods = [
+        m for m in ("frequentist", "bayesian", "continuous") if results.get(m)
+    ]
+    if active_monetary_methods:
+        # Lets Gemini reason about which method's "effect on revenue" is most
+        # defensible for this specific experiment (sample size, whether the
+        # KPI is a rate or revenue itself, significance status) rather than
+        # treating the three as interchangeable — same notes shown to the
+        # human in Step 3.
+        ai_input["monetary_method_notes"] = {
+            m: MONETARY_METHOD_NOTES[m] for m in active_monetary_methods
+        }
+        if len(active_monetary_methods) > 1:
+            ai_input["monetary_method_guidance"] = MONETARY_METHOD_GUIDANCE
     if custom_code:
         # Optional context, not gated on — helps Gemini interpret what was
         # actually being tested (e.g. which element/variant the code touches).

--- a/utility/automation_engine.py
+++ b/utility/automation_engine.py
@@ -76,6 +76,59 @@ _TAIL_MAP = {
 
 TAILS = list(_TAIL_MAP.keys())
 
+# Each method's monetary estimate rests on different assumptions and is
+# appropriate in different situations -- surfaced both in the Step 3 UI and
+# in the AI-conclusion payload, so a human (or Gemini) picking which
+# "effect on revenue" number to trust for a given experiment can weigh the
+# trade-offs rather than treating all three as interchangeable.
+MONETARY_METHOD_NOTES: dict[str, dict[str, list[str]]] = {
+    "frequentist": {
+        "pros": [
+            "Deterministic, closed-form estimate tied directly to the same confidence interval as the significance test -- no simulation noise, identical result every run.",
+            "Correctly handles one-sided tests: an unbounded CI renders as an explicit 'at least X' / 'at most Y' claim rather than a fabricated number.",
+            "Cheapest to compute and the easiest of the three to explain to a non-technical audience.",
+        ],
+        "cons": [
+            "Decomposes revenue into rate x AOV separately, rather than modelling revenue's actual (right-skewed, non-negative) distribution.",
+            "Relies on a normal approximation (CLT); the interval can be less reliable on small samples or highly variable AOV.",
+            "A non-significant result renders only as a blunt 'treat as illustrative' hedge -- no expected-value read on whether shipping anyway would be a reasonable bet.",
+        ],
+    },
+    "bayesian": {
+        "pros": [
+            "Full posterior distribution, not just a point estimate + CI -- captures asymmetric uncertainty naturally instead of assuming a symmetric normal spread.",
+            "Separates expected upside from expected downside risk explicitly, giving a decision-theoretic 'is this bet worth it' read even before conventional significance is reached.",
+            "A lift prior guards against small-sample overestimation of implausibly large effects.",
+        ],
+        "cons": [
+            "Monte Carlo based -- more expensive to compute, and the exact figure carries sampling noise across runs (controlled by the sample-size setting, but never fully eliminated).",
+            "Always produces an expected-value number, even for a genuinely inconclusive result -- read alongside prob_beat_control/prob_being_best, never the money figure alone.",
+            "AOV is modelled as log-normal with an assumed variability (CV); if that's a poor match for the real order-value distribution, the estimate's spread (not its mean) is affected.",
+        ],
+    },
+    "continuous": {
+        "pros": [
+            "Uses the actual row-level revenue data directly (Gamma-fitted), rather than reconstructing revenue from rate x AOV -- the most direct measure when revenue itself is the KPI.",
+            "RPV vs RPT isolates whether an effect comes from more people converting, from each buyer spending more, or both.",
+            "Correctly models revenue's right-skewed, non-negative shape instead of assuming normality on the raw values.",
+        ],
+        "cons": [
+            "Still uses a normal-approximation (delta-method) CI on top of the Gamma-fitted group means -- inherits the same CLT caveats as Frequentist, just applied to fitted statistics instead of a raw proportion.",
+            "RPT counts buyers only, so its effective sample size can be much smaller than RPV's -- wider, less stable intervals on modest traffic.",
+            "Needs the separate continuous/row-level data fetch (extra BigQuery scan cost) that the other two methods don't require.",
+        ],
+    },
+}
+
+MONETARY_METHOD_GUIDANCE = (
+    "Rough guide to which source tends to fit best: a rate-based test with fairly stable AOV -- "
+    "Frequentist or Bayesian on binomial data is simplest and cheapest. Revenue or AOV itself is the "
+    "KPI (pricing, upsell, merchandising) -- Continuous is the most direct measure. Small sample or a "
+    "pre-significance ship/hold decision -- Bayesian's expected-value framing is more informative than "
+    "a flat non-significant verdict. Need a simple, easily-defensible number for a non-technical or "
+    "finance audience -- Frequentist's closed-form CI is the most transparent."
+)
+
 
 @dataclass
 class VariantData:
@@ -125,6 +178,13 @@ def run_frequentist_analysis(
         se_aov_chal=se_aov_var,
     )
 
+    monetary_conclusion = FrequentistEngine.generate_monetary_conclusion(
+        variant_name=variation.label,
+        monetary_result=monetary,
+        is_significant=result.is_significant,
+        alternative=alternative,
+    )
+
     return {
         "method": "frequentist",
         "p_value": result.p_value,
@@ -132,6 +192,7 @@ def run_frequentist_analysis(
         "uplift": result.uplift,
         "ci_diff": result.ci_diff,
         "conclusion": result.conclusion,
+        "monetary_conclusion": monetary_conclusion,
         "effect_on_revenue": monetary["point_estimate"],
         "effect_on_revenue_ci": (monetary["ci_low"], monetary["ci_high"]),
         "projection_days": projection_days,
@@ -179,6 +240,11 @@ def run_bayesian_analysis(
         "expected_uplift": prob_result.expected_uplift,
         "expected_loss": prob_result.expected_loss,
         "conclusion": prob_result.conclusion,
+        # generate_bayesian_conclusion's output, already computed inside
+        # run_monetary_projection (Strong Winner / Clear Loser / Asymmetric
+        # Bet / Inconclusive framing) — prob_result.conclusion above is
+        # probability-only and never mentions money at all.
+        "monetary_conclusion": monetary["conclusion"],
         "effect_on_revenue": monetary["expected_total_contribution"],
         "expected_revenue_uplift": monetary["expected_uplift"],
         "expected_revenue_risk": monetary["expected_risk"],
@@ -262,6 +328,15 @@ def run_continuous_analysis(
         monetary_list[0] if monetary_list else None,
     )
 
+    monetary_conclusion = (
+        ContinuousMetricEngine.generate_monetary_conclusion(
+            variant_name=variation_label,
+            monetary_result=monetary,
+            is_significant=result.is_significant,
+        )
+        if monetary else None
+    )
+
     return {
         "method": "continuous",
         "mode": mode,
@@ -270,6 +345,7 @@ def run_continuous_analysis(
         "p_value": result.p_value,
         "is_significant": result.is_significant,
         "conclusion": result.conclusion,
+        "monetary_conclusion": monetary_conclusion,
         "summary_stats": result.summary_stats,
         "effect_on_revenue": monetary["point_estimate"] if monetary else 0.0,
         "effect_on_revenue_ci": (monetary["ci_low"], monetary["ci_high"]) if monetary else (0.0, 0.0),

--- a/utility/gemini_client.py
+++ b/utility/gemini_client.py
@@ -24,13 +24,24 @@ also include a "custom_code" field — the actual implementation code for the
 variation — use it only to understand what was really being tested, not as
 something to comment on directly.
 
+When more than one method was run, the data includes "monetary_method_notes"
+(pros/cons of each method's revenue estimate) and, if more than one method
+has a monetary estimate, "monetary_method_guidance" (a rough rule of thumb
+for which tends to fit which situation). Use these to judge which method's
+"effect on revenue" is the most defensible one for THIS experiment (its
+sample size, whether the KPI is a conversion rate or revenue itself, and
+whether the result reached significance) — do not just default to whichever
+one the payload happens to use for its "effect_on_revenue" field. If two
+methods disagree noticeably, say so and explain which number you'd trust
+more and why, rather than silently picking one.
+
 Make sure that you structure your answer thorougly by KPI. Each KPI should have a headline like this before summarizing the results:
 KPI: [KPI] ([test type], [Percentage] Confidence, [Percentage] Power)
 
 Write a short, plain-language conclusion (3-6 sentences), IN DUTCH, that a
 stakeholder without a statistics background could act on. Cover:
 - Whether the result is statistically significant / conclusive, and how confident to be (per KPI).
-- The practical size of the effect (uplift, revenue impact) if available (per KPI).
+- The practical size of the effect (uplift, revenue impact) if available (per KPI), noting which method's revenue estimate you're relying on and why when more than one is available.
 - A clear recommendation: ship the variation, keep testing, or stop/iterate (based on all KPIs).
 - If there is sufficient data to infer it, also write a possible explanation from a psychological angle using known principles, fallacies, biases (based on all KPIs).
 - Be cautious in your final conclusions and rather use 'the data suggests' instead of 'it is clear that'. when drawing a conclusion. Use a scientific mind, but plain and concise language to communicate the findings.


### PR DESCRIPTION
## Summary
Each FOE engine (Frequentist, Bayesian, Continuous) has its own written monetary-conclusion method, computed from data already available at the point each `run_*_analysis` function returns — but none of them were ever called (Frequentist, Continuous), or the already-computed string was discarded (Bayesian's monetary conclusion was built inside `run_monetary_projection` and thrown away in favor of a probability-only one). The Airtable/AI payload therefore only ever carried numeric fields plus a bare statistical-significance conclusion, leaving Gemini to reconstruct revenue-impact nuance (one-sided CI wording, non-significant hedging, Bayesian risk/reward framing) from raw numbers alone.

- `run_frequentist_analysis` / `run_continuous_analysis` now also return `monetary_conclusion` (their engine's `generate_monetary_conclusion` output) — no new computation, uses data already on hand.
- `run_bayesian_analysis` now surfaces the monetary conclusion already built inside `run_monetary_projection` instead of discarding it — this one was already free.
- New `MONETARY_METHOD_NOTES` / `MONETARY_METHOD_GUIDANCE` in `automation_engine.py`: pros/cons of each method's monetary estimate, and a rough rule of thumb for which fits which situation (rate-based vs. revenue-as-KPI, small-sample ship/hold decisions, non-technical audiences).
- Step 3 now shows each active method's `monetary_conclusion` caption plus a "Pros & cons" expander, and a comparison banner when more than one monetary-bearing method is active.
- Step 4's `ai_input` now includes `monetary_method_notes` (scoped to whichever methods actually ran) and `monetary_method_guidance` (when >1 is active). Updated the Gemini prompt to explicitly judge which method's revenue number is most defensible for the specific experiment, rather than defaulting to whichever one the payload happens to use, and to call out disagreement between methods rather than silently picking one.

## Test plan
- `py_compile` clean on all touched files; `pyflakes` diff before/after is identical (zero new lint issues)
- Confirmed no new imports/dependencies introduced (diff-checked)
- Fresh `pip install -r requirements.txt` into an empty venv (simulating a real Streamlit Cloud rebuild) — `streamlit==1.56.0` resolves as pinned, `tornado` present, no `starlette`/`uvicorn` in the tree, `pip check` clean
- AppTest, run against that freshly-installed environment:
  - `main.py` and `automation.py` Steps 1/5 regression-checked, no exceptions
  - Step 3 with all three methods active: all three "Pros & cons" expanders render, comparison guidance banner shows; single-method case correctly omits the banner
  - Step 4 `ai_input`: `monetary_method_notes` contains exactly the active methods' keys, `monetary_method_guidance` present only when >1 method is active
  - Verified each engine's `monetary_conclusion` text directly (Frequentist point estimate + CI, Bayesian risk/reward framing, Continuous's "not statistically significant — treat as directional" hedge on a non-significant result)