### PR TITLE
Continuous device join no longer drops users lacking desktop/mobile e…

### DIFF
--- a/utility/sql_builder.py
+++ b/utility/sql_builder.py
@@ -798,7 +798,7 @@ SELECT
   ed.transaction_id
 FROM variant_data vd
 {join_type} ecommerce_data ed ON vd.user_pseudo_id = ed.user_pseudo_id
-INNER JOIN device_data      dd ON vd.user_pseudo_id = dd.device_user_pseudo_id
+LEFT JOIN device_data       dd ON vd.user_pseudo_id = dd.device_user_pseudo_id
 WHERE ('{p.device_filter}' = 'all' OR dd.primary_device = '{p.device_filter}')
 ORDER BY ed.purchase_revenue DESC{limit_clause};
 """
@@ -1313,7 +1313,7 @@ SELECT
   ed.transaction_id
 FROM variant_data vd
 {join_type} ecommerce_data ed ON vd.user_pseudo_id = ed.user_pseudo_id
-INNER JOIN device_data      dd ON vd.user_pseudo_id = dd.device_user_pseudo_id
+LEFT JOIN device_data       dd ON vd.user_pseudo_id = dd.device_user_pseudo_id
 {filter_join}WHERE ('{p.device_filter}' = 'all' OR dd.primary_device = '{p.device_filter}')
 ORDER BY ed.purchase_revenue DESC"""
 


### PR DESCRIPTION
## Summary

Continuous experiment exports (`build_continuous` / `build_continuous_from_shared_scan` in `utility/sql_builder.py`) silently dropped users from the result set based on device category, even when the device filter was set to "all".

## The bug

Both continuous builders `INNER JOIN`ed `device_data`:

```sql
INNER JOIN device_data      dd ON vd.user_pseudo_id = dd.device_user_pseudo_id
WHERE ('{p.device_filter}' = 'all' OR dd.primary_device = '{p.device_filter}')
```

device_data only contains users with at least one desktop- or mobile-categorized event (WHERE device_category IN ('desktop', 'mobile')). Any exposed user whose events were exclusively tablet, smart TV, or had no device category recorded never got a device_data row — and the INNER JOIN dropped them from the export entirely, before the 'all' = 'all' OR ... WHERE clause ever got a chance to include them back. device_filter='all' looks like "no restriction" but wasn't.

automation.py hardcodes device_filter="all" for its continuous fetch, so this ran on every automation continuous export.

Binomial's equivalent join (when kpi_device_split is on) was already a LEFT JOIN — this was the same kind of asymmetry as the post_exposure_filter no-op fixed in the previous PR.

## Fix
Switched both continuous builders to LEFT JOIN device_data. Verified:

device_filter='all': users with no device match (dd.primary_device IS NULL) are now kept, since 'all' = 'all' short-circuits the WHERE clause regardless of primary_device.
device_filter='desktop'/'mobile': unchanged — users without a matching primary_device are still excluded, same as before.
Verification

Generated SQL for all three device_filter values (all, desktop, mobile) on both builders (standalone and shared-scan) and confirmed the join type and resulting WHERE semantics.
On the specific dataset examined in the prior investigation, this bug had zero measurable effect (Continuous's unique-visitor count already matched Binomial's exactly) — but it's a live risk for any property/experiment with meaningful tablet, smart-TV, or unset-device-category traffic, since those users would previously have been silently excluded from every continuous export regardless of device filter.