### PR TITLE
Fix continuous RPV double-counting and other automation-wizard audit findings

### DIFF
--- a/pages/automation.py
+++ b/pages/automation.py
@@ -48,6 +48,7 @@ from utility.automation_engine import (
     run_bayesian_analysis,
     run_continuous_analysis,
     run_pretest_analysis,
+    run_pretest_analysis_seasonal,
     build_airtable_payload,
     apply_field_map,
     best_match_field,
@@ -188,6 +189,21 @@ def _render_stage_fetch():
                 options=list(PRETEST_KPI_OPTIONS.keys()),
                 key="autofetch_pretest_kpi",
             )
+        use_seasonal_pretest = st.checkbox(
+            "Use seasonal forecast (Prophet) instead of a flat weekly average",
+            value=False,
+            key="autofetch_pretest_seasonal",
+            help=(
+                "Fits a Prophet model to daily baseline traffic/conversions and "
+                "projects the next 6 weeks with weekly/yearly seasonality, instead "
+                "of assuming flat traffic — useful around holidays or promo periods "
+                "that would otherwise be averaged away. Needs at least 14 days of "
+                "daily baseline history (hard minimum), but yearly seasonality is "
+                "only meaningfully estimated with several months of history — with "
+                "just a few weeks, later forecast weeks can flatten out unreliably. "
+                "Prefer 8+ weeks above when this is on."
+            ),
+        )
 
         try:
             experiment_start = datetime.strptime(start_date, "%Y-%m-%d").date()
@@ -202,6 +218,19 @@ def _render_stage_fetch():
                 f"Baseline period: **{baseline_start}** to **{baseline_end}** "
                 f"({int(weeks_before)} full week(s), Monday-Sunday)."
             )
+            baseline_days = (baseline_end - baseline_start).days + 1
+            if use_seasonal_pretest and baseline_days < 14:
+                st.warning(
+                    "Seasonal forecasting needs at least 14 days of daily baseline "
+                    "history — pick 2 or more weeks above, or turn it off."
+                )
+            elif use_seasonal_pretest and baseline_days < 56:
+                st.caption(
+                    "ℹ️ With under ~8 weeks of history, Prophet's yearly-seasonality "
+                    "component is poorly estimated and later forecast weeks can "
+                    "flatten out unrealistically — treat this as directional, or "
+                    "pick more weeks above for a more reliable projection."
+                )
 
             filter_type, filter_value = render_user_filter(
                 project, dataset, str(baseline_start), str(baseline_end),
@@ -214,15 +243,16 @@ def _render_stage_fetch():
                 start_date=str(baseline_start),
                 end_date=str(baseline_end),
                 output_type="binomial",
-                output_shape="aggregate",
+                output_shape="daily" if use_seasonal_pretest else "aggregate",
                 kpi_add_to_cart=(PRETEST_KPI_OPTIONS[kpi_choice] == "add_to_cart"),
                 filter_type=filter_type,
                 filter_value=filter_value,
             )
             baseline_sql = build_baseline(baseline_params)
             render_sql_viewer(baseline_sql, key="auto_pretest_sql")
+            pretest_result_key = "auto_pretest_daily_result" if use_seasonal_pretest else "auto_pretest_result"
             render_execution_gate(
-                project, baseline_sql, result_key="auto_pretest_result", allow_preview=True,
+                project, baseline_sql, result_key=pretest_result_key, allow_preview=True,
                 dataset=dataset,
             )
 
@@ -383,10 +413,27 @@ def _render_stage_fetch():
             st.session_state["auto_runtime_days"] = 1
 
         df_pretest = st.session_state.get("auto_pretest_result")
+        df_pretest_daily = st.session_state.get("auto_pretest_daily_result")
         st.session_state["auto_df_pretest"] = df_pretest
-        if df_pretest is not None and not df_pretest.empty:
+        use_seasonal = bool(st.session_state.get("autofetch_pretest_seasonal", False))
+        kpi_choice = st.session_state.get("autofetch_pretest_kpi", "Transactions (purchases)")
+
+        if use_seasonal and df_pretest_daily is not None and not df_pretest_daily.empty:
             weeks = int(st.session_state.get("autofetch_pretest_weeks", 1))
-            kpi_choice = st.session_state.get("autofetch_pretest_kpi", "Transactions (purchases)")
+            value_col = (
+                "add_to_cart_conversions"
+                if PRETEST_KPI_OPTIONS[kpi_choice] == "add_to_cart"
+                else "conversions"
+            )
+            st.session_state["auto_pretest_meta"] = {
+                "seasonal": True,
+                "weeks": weeks,
+                "kpi_label": kpi_choice,
+                "daily_df": df_pretest_daily,
+                "value_col": value_col,
+            }
+        elif df_pretest is not None and not df_pretest.empty:
+            weeks = int(st.session_state.get("autofetch_pretest_weeks", 1))
             row = df_pretest.iloc[0]
             conversions_col = (
                 "total_add_to_cart_conversions"
@@ -394,6 +441,7 @@ def _render_stage_fetch():
                 else "total_conversions"
             )
             st.session_state["auto_pretest_meta"] = {
+                "seasonal": False,
                 "weeks": weeks,
                 "kpi_label": kpi_choice,
                 "total_visitors": float(row["total_visitors"]),
@@ -578,12 +626,18 @@ def _render_stage_configure():
                 "Power / trustworthiness target (%)", min_value=50, max_value=99,
                 value=80, step=1, key="auto_pretest_trust",
             )
-            weekly_visitors = pretest_meta["total_visitors"] / pretest_meta["weeks"]
-            weekly_conversions = pretest_meta["total_conversions"] / pretest_meta["weeks"]
-            st.caption(
-                f"Baseline: {pretest_meta['kpi_label']} over {pretest_meta['weeks']} week(s) → "
-                f"{weekly_visitors:,.0f} visitors/week, {weekly_conversions:,.1f} conversions/week."
-            )
+            if pretest_meta.get("seasonal"):
+                st.caption(
+                    f"Baseline: {pretest_meta['kpi_label']} · {pretest_meta['weeks']} week(s) of "
+                    "daily history · seasonal (Prophet) forecast, not a flat weekly average."
+                )
+            else:
+                weekly_visitors = pretest_meta["total_visitors"] / pretest_meta["weeks"]
+                weekly_conversions = pretest_meta["total_conversions"] / pretest_meta["weeks"]
+                st.caption(
+                    f"Baseline: {pretest_meta['kpi_label']} over {pretest_meta['weeks']} week(s) → "
+                    f"{weekly_visitors:,.0f} visitors/week, {weekly_conversions:,.1f} conversions/week."
+                )
     else:
         trust_pct = 80
 
@@ -597,7 +651,12 @@ def _render_stage_configure():
             aov_cv = st.slider(
                 "AOV variability (CV)", min_value=0.0, max_value=1.5,
                 value=0.0, step=0.05, key="auto_aov_cv",
-                help="0 treats AOV as a known constant. Above 0 propagates AOV sampling uncertainty (Frequentist only).",
+                help=(
+                    "0 treats AOV as a known constant for both methods. Above 0: Frequentist "
+                    "propagates it as estimation-uncertainty on the AOV mean (widens the CI); "
+                    "Bayesian samples AOV from a log-normal with this CV on every simulated draw "
+                    "(widens the posterior spread). Same input, different mechanics per method."
+                ),
             )
         if use_continuous and daily_visitors_continuous != daily_visitors:
             st.caption(
@@ -662,6 +721,7 @@ def _render_stage_configure():
                     runtime_days=runtime_days,
                     projection_days=int(projection_days),
                     n_samples=int(n_samples),
+                    aov_cv=aov_cv,
                 )
             if use_continuous:
                 results["continuous"] = run_continuous_analysis(
@@ -675,15 +735,26 @@ def _render_stage_configure():
                     mode=continuous_mode,
                 )
             if use_pretest:
-                results["pretest"] = run_pretest_analysis(
-                    weekly_visitors=pretest_meta["total_visitors"] / pretest_meta["weeks"],
-                    weekly_conversions=pretest_meta["total_conversions"] / pretest_meta["weeks"],
-                    weeks_used=pretest_meta["weeks"],
-                    kpi_label=pretest_meta["kpi_label"],
-                    confidence_level=confidence_level,
-                    tail=tail,
-                    trust_pct=trust_pct,
-                )
+                if pretest_meta.get("seasonal"):
+                    results["pretest"] = run_pretest_analysis_seasonal(
+                        daily_df=pretest_meta["daily_df"],
+                        value_col=pretest_meta["value_col"],
+                        kpi_label=pretest_meta["kpi_label"],
+                        weeks_used=pretest_meta["weeks"],
+                        confidence_level=confidence_level,
+                        tail=tail,
+                        trust_pct=trust_pct,
+                    )
+                else:
+                    results["pretest"] = run_pretest_analysis(
+                        weekly_visitors=pretest_meta["total_visitors"] / pretest_meta["weeks"],
+                        weekly_conversions=pretest_meta["total_conversions"] / pretest_meta["weeks"],
+                        weeks_used=pretest_meta["weeks"],
+                        kpi_label=pretest_meta["kpi_label"],
+                        confidence_level=confidence_level,
+                        tail=tail,
+                        trust_pct=trust_pct,
+                    )
             st.session_state["auto_control"] = control
             st.session_state["auto_variation"] = variation
             st.session_state["auto_results"] = results
@@ -799,13 +870,20 @@ def _render_stage_results():
 
     if pretest:
         st.markdown("### Pre-Test Analysis")
-        st.caption(
-            f"Baseline: {pretest['kpi']} · {pretest['weeks_used']} week(s) · "
-            f"{pretest['weekly_visitors']:,.0f} visitors/week, "
-            f"{pretest['weekly_conversions']:,.1f} conversions/week."
-        )
-        mde_df = pd.DataFrame(pretest["table"])
-        st.dataframe(mde_df, use_container_width=True)
+        if pretest.get("seasonal"):
+            st.caption(
+                f"Baseline: {pretest['kpi']} · {pretest['weeks_used']} week(s) of daily "
+                f"history · seasonal (Prophet) forecast. {pretest.get('forecast_summary', '')}"
+            )
+        else:
+            st.caption(
+                f"Baseline: {pretest['kpi']} · {pretest['weeks_used']} week(s) · "
+                f"{pretest['weekly_visitors']:,.0f} visitors/week, "
+                f"{pretest['weekly_conversions']:,.1f} conversions/week."
+            )
+        if pretest["table"]:
+            mde_df = pd.DataFrame(pretest["table"])
+            st.dataframe(mde_df, use_container_width=True)
         st.caption(pretest["conclusion"])
         st.divider()
 
@@ -952,20 +1030,47 @@ def _lookup_experiment_record() -> tuple[list[str], Optional[dict], str]:
     if not matches:
         return table["fields"], None, f"No Airtable record found yet for experiment '{exp_prefix}'."
 
-    # Prefer a match that already has a Hypothesis filled in, if more than one
-    # record matched the search term — otherwise just take the first.
     hypothesis_field = _guess_hypothesis_field(table["fields"])
-    matched = None
-    if hypothesis_field:
-        matched = next(
-            (r for r in matches if str(r["fields"].get(hypothesis_field, "")).strip()), None,
+
+    if len(matches) > 1:
+        # search_records matches by substring (see its own docstring), so more
+        # than one record legitimately containing exp_prefix is a real
+        # possibility (e.g. "104" also matching "1041..."), not just a rare
+        # edge case. Silently picking one on the user's behalf risked
+        # attaching this result — and the AI conclusion — to the wrong
+        # experiment's record with no indication anything was ambiguous.
+        # Surface every candidate and let the user confirm, defaulting to the
+        # same "prefer a match with a filled Hypothesis" pick as before.
+        def _match_label(r: dict) -> str:
+            id_value = r["fields"].get(id_field, "(blank)")
+            has_hyp = bool(hypothesis_field and str(r["fields"].get(hypothesis_field, "")).strip())
+            marker = "  ·  ✓ has hypothesis" if has_hyp else ""
+            return f"{id_value}  ·  …{r['id'][-6:]}{marker}"
+
+        default_match = next(
+            (r for r in matches if hypothesis_field and str(r["fields"].get(hypothesis_field, "")).strip()),
+            matches[0],
         )
-    matched = matched or matches[0]
+        options = [_match_label(r) for r in matches]
+        st.warning(
+            f"{len(matches)} Airtable records matched '{exp_prefix}' on **{id_field}** — "
+            "confirm which one this experiment's result actually belongs to."
+        )
+        choice = st.selectbox(
+            "Matched record", options=options,
+            index=matches.index(default_match),
+            key="auto_lookup_record_choice",
+        )
+        matched = matches[options.index(choice)]
+        message = f"Matched Airtable record for '{exp_prefix}' ({len(matches)} candidates — confirm above)."
+    else:
+        matched = matches[0]
+        message = f"Matched Airtable record for '{exp_prefix}'."
 
     resolved["record_id"] = matched["id"]
     resolved["record_fields"] = matched["fields"]
     resolved["search_term"] = exp_prefix
-    return table["fields"], matched["fields"], f"Matched Airtable record for '{exp_prefix}'."
+    return table["fields"], matched["fields"], message
 
 
 def _render_stage_ai():
@@ -1374,6 +1479,22 @@ def _render_stage_send():
                             field_map[key] = chosen
 
                     st.session_state[mapping_key] = field_map
+
+                    # apply_field_map has no way to detect this: two internal
+                    # keys mapped to the same Airtable field silently collapse
+                    # to whichever one dict iteration processes last, dropping
+                    # the other's value with no error. Only a UI-level warning
+                    # can catch it, since the collision only exists at the
+                    # point the user picks the mapping.
+                    chosen_fields = list(field_map.values())
+                    dupes = sorted({f for f in chosen_fields if chosen_fields.count(f) > 1})
+                    if dupes:
+                        dupe_list = ", ".join(dupes)
+                        st.warning(
+                            f"Multiple result fields are mapped to the same Airtable column "
+                            f"({dupe_list}) — only one value will actually be sent for each, "
+                            "silently dropping the rest. Fix the mapping above before sending."
+                        )
 
                     if mode == "update" or description.strip():
                         send_plan.append({

--- a/utility/automation_engine.py
+++ b/utility/automation_engine.py
@@ -104,6 +104,7 @@ MONETARY_METHOD_NOTES: dict[str, dict[str, list[str]]] = {
             "Monte Carlo based -- more expensive to compute, and the exact figure carries sampling noise across runs (controlled by the sample-size setting, but never fully eliminated).",
             "Always produces an expected-value number, even for a genuinely inconclusive result -- read alongside prob_beat_control/prob_being_best, never the money figure alone.",
             "AOV is modelled as log-normal with an assumed variability (CV); if that's a poor match for the real order-value distribution, the estimate's spread (not its mean) is affected.",
+            "Projects future volume by scaling each variant's OWN observed visitors by runtime_days -- i.e. assumes the traffic split observed during the test continues. Frequentist/Continuous instead scale a single combined daily-visitor figure -- i.e. assume the winner is rolled out to 100% of future traffic. The two are not projecting the same future and their revenue figures are not directly comparable.",
         ],
     },
     "continuous": {
@@ -126,7 +127,14 @@ MONETARY_METHOD_GUIDANCE = (
     "KPI (pricing, upsell, merchandising) -- Continuous is the most direct measure. Small sample or a "
     "pre-significance ship/hold decision -- Bayesian's expected-value framing is more informative than "
     "a flat non-significant verdict. Need a simple, easily-defensible number for a non-technical or "
-    "finance audience -- Frequentist's closed-form CI is the most transparent."
+    "finance audience -- Frequentist's closed-form CI is the most transparent. IMPORTANT: the three "
+    "figures are not a like-for-like comparison even before uncertainty is considered -- Frequentist "
+    "and Continuous project revenue assuming the winning variant is rolled out to 100% of future "
+    "traffic (today's combined daily visitors), while Bayesian projects forward assuming the SAME "
+    "traffic split observed during the test continues (each arm scaled by its own historical daily "
+    "visitors). In an even split, Bayesian's figure will run roughly half of Frequentist/Continuous's "
+    "for a comparable effect size -- that gap reflects differing rollout assumptions, not disagreement "
+    "about the underlying effect."
 )
 
 
@@ -205,8 +213,18 @@ def run_bayesian_analysis(
     runtime_days: int,
     projection_days: int,
     n_samples: int = 100_000,
+    aov_cv: float = 0.5,
 ) -> dict:
-    """Runs the FOE BayesianEngine (Beta-Binomial Monte Carlo) on a control/variation pair."""
+    """
+    Runs the FOE BayesianEngine (Beta-Binomial Monte Carlo) on a control/variation pair.
+
+    aov_cv is the same "AOV variability (CV)" the UI collects for Frequentist's
+    se_aov propagation, passed through to BayesianEngine.run_monetary_projection's
+    log-normal AOV sampling instead of silently falling back to its 0.5 default
+    regardless of what the user set — the two methods use the CV differently
+    (Frequentist propagates it as an estimation-uncertainty SE; Bayesian samples
+    AOV directly from it each draw), but both should reflect the same input.
+    """
     data = ExperimentInput(
         visitors=[control.visitors, variation.visitors],
         conversions=[control.conversions, variation.conversions],
@@ -230,6 +248,7 @@ def run_bayesian_analysis(
         biz_case=biz_case,
         prob_best_overall=prob_best_overall,
         variant_labels=[control.label, variation.label],
+        aov_cv=aov_cv,
         n_simulations=n_samples,
     )[0]
 
@@ -272,32 +291,50 @@ def run_continuous_analysis(
     projection.
 
     automation.py's continuous fetch always uses the "all_users" (LEFT JOIN)
-    query mode, so every exposed visitor is a row, non-buyers as NULL revenue
-    (zero-filled below) rather than dropped — this is what makes both modes
-    below possible from the *same* fetched data:
+    query mode, so every exposed visitor gets at least one row, non-buyers as
+    NULL revenue (zero-filled below) rather than dropped. A visitor who placed
+    more than one separate order within the date range gets *multiple* rows,
+    though — one per transaction, from the underlying SQL's per-order grain —
+    so the raw fetch is really "one row per (visitor, order)", not "one row
+    per visitor". That distinction matters differently per mode:
 
-    mode="rpv" (revenue per visitor): every row counts as-is — measures
-    conversion-rate AND spend effects together (AnalysisUnit.PER_VISITOR).
-    mode="rpt" (revenue per transaction): only buyers should count, so zero-
-    revenue rows are stripped before analysis (AnalysisUnit.PER_TRANSACTION)
-    — isolates the order-value effect alone. Each variant's total exposed
-    visitor count is taken from the data *before* that stripping and passed
-    through to the monetary projection regardless of mode, since FOE's
-    PER_TRANSACTION business case needs it to derive an order rate (n
-    orders / total visitors) — without it, a per-order lift can't be scaled
-    to daily traffic.
+    mode="rpv" (revenue per visitor): needs exactly one row per visitor
+    (AnalysisUnit.PER_VISITOR — FOE's own hurdle model assumes the group mean
+    already averages over every visitor). Rows are first collapsed to one per
+    (variant, visitor) by summing revenue, so a repeat purchaser contributes
+    their total spend as a single observation instead of being counted (and
+    weighted in the significance test) once per order.
+    mode="rpt" (revenue per transaction): the raw per-order grain *is* what's
+    wanted — only buyers should count, so zero-revenue rows are stripped
+    before analysis (AnalysisUnit.PER_TRANSACTION) — isolates the order-value
+    effect alone, one observation per order.
+
+    Each variant's total exposed visitor count (visitor_counts) is always the
+    count of *distinct* visitors, regardless of mode — computed before any
+    mode-specific collapsing/stripping, since FOE's PER_TRANSACTION business
+    case needs a true visitor count (not an order count) to derive an order
+    rate (n orders / total visitors); a repeat purchaser's extra rows must not
+    inflate it.
     """
     alternative = _TAIL_MAP[tail]
     alpha = 1.0 - confidence_level
 
     work = df.copy()
     work[kpi] = pd.to_numeric(work[kpi], errors="coerce").fillna(0.0)
-    visitor_counts = work["experience_variant_label"].value_counts().to_dict()
+    visitor_counts = (
+        work.groupby("experience_variant_label")["variant_user_pseudo_id"]
+        .nunique()
+        .to_dict()
+    )
 
     if mode == "rpt":
         work = work[work[kpi] != 0.0]
         unit = AnalysisUnit.PER_TRANSACTION
     else:
+        work = (
+            work.groupby(["experience_variant_label", "variant_user_pseudo_id"], as_index=False)[kpi]
+            .sum()
+        )
         unit = AnalysisUnit.PER_VISITOR
 
     config = ContinuousMetricConfig(
@@ -393,6 +430,84 @@ def run_pretest_analysis(
     }
 
 
+def run_pretest_analysis_seasonal(
+    daily_df: "pd.DataFrame",
+    value_col: str,
+    kpi_label: str,
+    weeks_used: int,
+    confidence_level: float,
+    tail: Literal["Two-sided", "Greater", "Less"],
+    trust_pct: float = 80.0,
+) -> dict:
+    """
+    Seasonal counterpart to run_pretest_analysis: fits a Prophet model to daily
+    baseline visitors/conversions (via FOE's TrafficForecastingEngine) and
+    projects a 6-week MDE table from that forecast instead of a flat weekly
+    average, so weekday/holiday patterns in the baseline period inform the
+    projection rather than being averaged away.
+
+    Note: pages/pre_test_analysis.py has its own, independent Prophet-based
+    seasonal forecast (run_prophet_forecast + perform_mde_calculation_forecast)
+    for its dedicated planning tool. This uses FOE's TrafficForecastingEngine /
+    PretestEngine.calculate_mde_from_forecast instead, since that page's helpers
+    aren't safely importable here (it calls st.set_page_config at module level,
+    which collides with automation.py's own call) — the two seasonal paths are
+    functionally equivalent (same Prophet weekly/yearly-seasonality fit, same
+    cumulative-week MDE formula) but independently implemented.
+
+    daily_df needs a 'report_date' column (as produced by
+    BaselineParams(output_shape="daily")) plus 'visitors' and `value_col`
+    (either 'conversions' or 'add_to_cart_conversions', matching the chosen
+    pretest KPI). Falls back to an explanatory empty-table result if there
+    isn't enough daily history (Prophet needs >= 14 days) or the forecast
+    comes back empty.
+    """
+    from foe.core.models import AnalysisUnit
+    from foe.pretest.forecasting import TrafficForecastingEngine
+
+    alternative = _TAIL_MAP[tail]
+    risk_pct = confidence_level * 100
+
+    df = daily_df.rename(columns={"report_date": "ds"})
+    df["ds"] = pd.to_datetime(df["ds"])
+    forecast_result = TrafficForecastingEngine.run_seasonal_forecast(
+        df, periods=42, interval=confidence_level,
+        unit=AnalysisUnit.PER_VISITOR, count_col="visitors", value_col=value_col,
+    )
+    records = forecast_result.get("forecast") or []
+    if not records:
+        return {
+            "method": "pretest",
+            "seasonal": True,
+            "kpi": kpi_label,
+            "weeks_used": weeks_used,
+            "table": [],
+            "conclusion": forecast_result.get(
+                "conclusion",
+                "Not enough daily baseline history for a seasonal forecast (need at least 14 days).",
+            ),
+        }
+
+    result = PretestEngine.calculate_mde_from_forecast(
+        forecast_records=records,
+        num_variants=2,
+        risk_pct=risk_pct,
+        trust_pct=trust_pct,
+        alternative=alternative,
+        unit=AnalysisUnit.PER_VISITOR,
+    )
+
+    return {
+        "method": "pretest",
+        "seasonal": True,
+        "kpi": kpi_label,
+        "weeks_used": weeks_used,
+        "table": result["table"],
+        "conclusion": result["conclusion"],
+        "forecast_summary": forecast_result["conclusion"],
+    }
+
+
 def format_pretest_table(table: list[dict]) -> str:
     """
     Renders the pre-test MDE table as plain text, one line per week, instead
@@ -405,6 +520,11 @@ def format_pretest_table(table: list[dict]) -> str:
     would multiply it by 100 a second time (12.42 -> "1242.29%" instead of
     "12.42%"), inflating every MDE in the table by exactly 100x before it
     ever reaches Airtable.
+
+    MDE can be None on the seasonal path (PretestEngine.calculate_mde_from_forecast
+    leaves a week's MDE unset when that week's forecasted volume is zero or
+    negative) -- run_pretest_analysis's flat-average path never produces None,
+    but this function is shared by both, so it's guarded here either way.
     """
     lines = []
     for row in table:
@@ -412,7 +532,9 @@ def format_pretest_table(table: list[dict]) -> str:
         size_label = size_key.replace("_", " ").lower() if size_key else ""
         size_val = row.get(size_key) if size_key else None
         size_part = f"{size_val:,} {size_label}" if size_val is not None else ""
-        lines.append(f"Week {row['Week']}: {size_part} — MDE {row['MDE']:.2f}%")
+        mde_val = row.get("MDE")
+        mde_part = f"{mde_val:.2f}%" if mde_val is not None else "N/A"
+        lines.append(f"Week {row['Week']}: {size_part} — MDE {mde_part}")
     return "\n".join(lines)
 
 

--- a/utility/sql_builder.py
+++ b/utility/sql_builder.py
@@ -897,15 +897,25 @@ def _shared_scan_user_filter(filter_type: Optional[str], filter_value: str) -> s
     column (see experiment_shared_scan_flags). Returns "" when disabled, and
     the CTE body WITHOUT a trailing comma or trailing newline — callers splice
     it into their own CTE chain and add a comma only if something follows it.
+
+    "contains"/"regex" is restricted to event_name = 'page_view', matching
+    _baseline_user_filter and the "Page URL — contains/regex... matches
+    page_view's page_location" UI copy (see render_user_filter). Without this,
+    shared_scan's page_location column — populated for ANY event that happens
+    to carry that param, e.g. click/scroll/video/file_download under GA4's
+    enhanced measurement — would scope the main experiment population
+    differently than the pre-test baseline population built from the same
+    filter UI, silently undermining the baseline-vs-experiment comparison
+    Pre-Test Analysis exists for.
     """
     if not (filter_type and filter_value):
         return ""
     if filter_type == "event":
         condition = f"event_name = '{filter_value}'"
     elif filter_type == "regex":
-        condition = f"REGEXP_CONTAINS(page_location, r'{filter_value}')"
+        condition = f"event_name = 'page_view' AND REGEXP_CONTAINS(page_location, r'{filter_value}')"
     else:
-        condition = f"page_location LIKE '%{filter_value}%'"
+        condition = f"event_name = 'page_view' AND page_location LIKE '%{filter_value}%'"
     return f"""
 filtered_users AS (
   SELECT DISTINCT user_pseudo_id


### PR DESCRIPTION
## Summary

A scrutiny pass over the Automation wizard (data fetch through send) turned up several correctness/consistency gaps not covered by the recent runtime/continuous fixes. Ranked by severity, all fixed here:

- **Continuous RPV double-counted repeat purchasers.** `ecommerce_data`'s grain is one row per order, so a visitor with 2+ separate purchases in the date range fanned out into multiple rows. `run_continuous_analysis` treated every row as an independent "visitor" for RPV mode, deflating the reported mean and — more seriously — violating the Gamma-hurdle significance test's independence assumption (FOE's own `PER_VISITOR` docstring assumes one row per visitor), understating p-values and CIs. Fixed by computing `visitor_counts` as `nunique(user)` and collapsing RPV's working frame to one row per (variant, visitor) before analysis; RPT is unaffected since it wants per-order granularity. Verified end-to-end against the real FOE engine with a synthetic repeat purchaser.
- **Frequentist/Continuous vs. Bayesian revenue-projection mismatch.** Frequentist/Continuous project "effect on revenue" assuming 100% future rollout (today's combined daily visitors); Bayesian assumes the traffic split observed during the test continues (each arm scaled by its own historical visitors, internally in FOE). The wizard puts all three side by side and lets Gemini reconcile disagreements, without disclosing they answer different questions. Documented in `MONETARY_METHOD_GUIDANCE` and Bayesian's cons list — surfaces in both the Step 3 UI and the Step 4 Gemini payload.
- **Page URL filter inconsistency.** The main experiment fetch's "contains/regex" filter matched `page_location` off any event; the pre-test baseline fetch restricted it to `page_view`. Same UI label, two different population definitions in one wizard run. Unified on the `page_view` restriction.
- **Ambiguous Airtable record lookup.** Step 4's substring-matched record lookup silently picked one candidate when more than one matched, risking a result landing on the wrong experiment's record. Now shows every match for the user to confirm.
- **Field-mapping collisions.** Step 5 had no guard against two payload keys mapping to the same Airtable field, silently dropping one value on send. Now warns.
- **Seasonal pretest forecast (opt-in).** Added a Prophet-based seasonal MDE projection alongside the existing flat weekly average, via FOE's `TrafficForecastingEngine`/`calculate_mde_from_forecast`. Verified end-to-end with a real Prophet fit; also added a caption warning below ~8 weeks of baseline history, since yearly seasonality is poorly estimated on short windows (a Prophet/data-volume characteristic shared with `pre_test_analysis.py`'s own seasonal tool).
- **Bayesian AOV CV.** The "AOV variability (CV)" slider only reached Frequentist; Bayesian silently used FOE's internal 0.5 default regardless. Now passed through.

## Test plan

- [x] `py_compile` clean on all touched files
- [x] `sql_builder.py` changes verified by rendering real SQL for filtered/unfiltered binomial and continuous builders, confirming the `page_view` restriction and unaffected event-mode filtering
- [x] `automation_engine.py` changes verified end-to-end against the real FOE engine (installed from the pinned commit): Frequentist, Bayesian (with `aov_cv` at 0 and 0.8), Continuous RPV and RPT with a synthetic repeat purchaser confirming the fan-out fix, flat pretest regression check, and a full seasonal-pretest run with a real Prophet fit
- [x] Manual click-through in the Streamlit app not performed (no live BigQuery/Airtable/Gemini credentials in this environment)