### PR TITLE
Fix incomplete continuous visitor-count fix and stale binomial/continuous carryover

### DIFF
--- a/pages/automation.py
+++ b/pages/automation.py
@@ -49,6 +49,7 @@ from utility.automation_engine import (
     run_continuous_analysis,
     run_pretest_analysis,
     run_pretest_analysis_seasonal,
+    collapse_to_per_visitor,
     build_airtable_payload,
     apply_field_map,
     best_match_field,
@@ -378,8 +379,15 @@ def _render_stage_fetch():
             project, sql, result_key=f"auto_{label}_result", allow_preview=True, dataset=dataset,
         )
 
-    df_binomial = st.session_state.get("auto_binomial_result")
-    df_continuous = st.session_state.get("auto_continuous_result")
+    # Gated on the current want_binomial/want_continuous checkbox state, not
+    # just whether a result happens to be cached under these keys -- without
+    # that gate, unchecking one after a previous combined fetch (e.g. after
+    # seeing the continuous scan's cost estimate) would silently carry the
+    # stale result forward into Step 2/3 with no warning, even mismatched
+    # against a since-changed experiment ID, date range, or filter if the
+    # user also changed those before re-fetching just the other one.
+    df_binomial = st.session_state.get("auto_binomial_result") if want_binomial else None
+    df_continuous = st.session_state.get("auto_continuous_result") if want_continuous else None
     if df_binomial is None and df_continuous is None:
         return
 
@@ -491,6 +499,16 @@ def _render_stage_configure():
         st.rerun()
         return
 
+    # The raw continuous fetch is one row per (visitor, order) pair, not one
+    # row per visitor -- see collapse_to_per_visitor's docstring. Computed
+    # once here and reused everywhere in this function that needs a visitor
+    # count or a per-visitor revenue figure (the preview table below,
+    # total_visitors, daily_visitors_continuous), so none of them can drift
+    # out of sync on what "visitor" means by re-deriving it locally.
+    per_visitor_continuous = (
+        collapse_to_per_visitor(df_continuous) if df_continuous is not None else None
+    )
+
     st.subheader("Step 2 — Choose analysis method(s)")
 
     control = variation = None
@@ -510,10 +528,10 @@ def _render_stage_configure():
             st.metric("Variation — conversions", f"{variation.conversions:,}", help=f"Rate: {rate:.2%}")
             st.metric("Variation — AOV", f"€{variation.aov:,.2f}")
 
-    if df_continuous is not None:
+    if per_visitor_continuous is not None:
         st.markdown("**Continuous data — revenue per visitor**")
         cont_summary = (
-            df_continuous.assign(purchase_revenue=pd.to_numeric(df_continuous["purchase_revenue"], errors="coerce").fillna(0.0))
+            per_visitor_continuous
             .groupby("experience_variant_label")["purchase_revenue"]
             .agg(["mean", "count"])
             .rename(columns={"mean": "revenue per visitor", "count": "visitors"})
@@ -569,8 +587,11 @@ def _render_stage_configure():
     if control is not None and variation is not None:
         total_visitors = control.visitors + variation.visitors
     else:
-        # Per-visitor rows (RPV query mode) — one row per exposed user.
-        total_visitors = len(df_continuous)
+        # per_visitor_continuous is already collapsed to one row per exposed
+        # visitor (see collapse_to_per_visitor) -- unlike df_continuous
+        # itself, which is one row per (visitor, order) and would over-count
+        # any repeat purchaser.
+        total_visitors = len(per_visitor_continuous)
     daily_visitors = total_visitors / runtime_days
 
     # Continuous's own population can differ from Binomial's even for the
@@ -582,9 +603,10 @@ def _render_stage_configure():
     # its own, potentially smaller population) would systematically over- or
     # under-state its monetary projection — so Continuous gets its own,
     # computed from its own fetched rows regardless of whether Binomial was
-    # also fetched.
+    # also fetched. Uses per_visitor_continuous's row count, not
+    # len(df_continuous), for the same reason as total_visitors above.
     daily_visitors_continuous = (
-        len(df_continuous) / runtime_days if df_continuous is not None else daily_visitors
+        len(per_visitor_continuous) / runtime_days if per_visitor_continuous is not None else daily_visitors
     )
 
     st.divider()

--- a/utility/automation_engine.py
+++ b/utility/automation_engine.py
@@ -271,6 +271,40 @@ def run_bayesian_analysis(
     }
 
 
+def collapse_to_per_visitor(df: "pd.DataFrame", kpi: str = "purchase_revenue") -> "pd.DataFrame":
+    """
+    Collapses a raw continuous fetch to exactly one row per (variant, visitor),
+    summing `kpi` across any separate orders a visitor placed in the date range.
+
+    automation.py's continuous fetch (build_continuous_from_shared_scan) is
+    one row per (visitor, order) pair, not one row per visitor -- its
+    ecommerce_data CTE groups by (user, transaction) to preserve per-order
+    values for RPT mode, and the final SELECT joins that back to one-row-per-
+    user variant_data on user_pseudo_id alone. A visitor with 2+ separate
+    purchases in range therefore gets 2+ rows; non-buyers (NULL revenue from
+    the LEFT JOIN, zero-filled here) get exactly one.
+
+    Every "per visitor" computation -- RPV's mean and its significance test,
+    a "how many visitors" count, revenue-per-visitor summaries, the future
+    daily-visitor scale used for revenue projections -- needs one row per
+    visitor, or it silently over-counts the population and under-counts
+    revenue-per-visitor for any repeat purchaser. This is the one place that
+    collapse happens; every one of those call sites should build on this
+    (or on `df["variant_user_pseudo_id"].nunique()` for a plain count) rather
+    than re-deriving it locally, so they can't drift out of sync on what
+    "visitor" means.
+
+    RPT mode wants the raw per-order rows instead (each order is its own
+    observation) -- do not use this for that path.
+    """
+    work = df.copy()
+    work[kpi] = pd.to_numeric(work[kpi], errors="coerce").fillna(0.0)
+    return (
+        work.groupby(["experience_variant_label", "variant_user_pseudo_id"], as_index=False)[kpi]
+        .sum()
+    )
+
+
 def run_continuous_analysis(
     df: "pd.DataFrame",
     control_label: str,
@@ -319,22 +353,21 @@ def run_continuous_analysis(
     alternative = _TAIL_MAP[tail]
     alpha = 1.0 - confidence_level
 
+    # per_visitor is already collapsed to one row per (variant, visitor), so
+    # a plain per-variant row count on it IS the true visitor_counts -- no
+    # separate nunique() needed, and it can't drift from what the RPV branch
+    # below actually analyzes since both come from the same collapse.
+    per_visitor = collapse_to_per_visitor(df, kpi)
+    visitor_counts = per_visitor.groupby("experience_variant_label").size().to_dict()
+
     work = df.copy()
     work[kpi] = pd.to_numeric(work[kpi], errors="coerce").fillna(0.0)
-    visitor_counts = (
-        work.groupby("experience_variant_label")["variant_user_pseudo_id"]
-        .nunique()
-        .to_dict()
-    )
 
     if mode == "rpt":
         work = work[work[kpi] != 0.0]
         unit = AnalysisUnit.PER_TRANSACTION
     else:
-        work = (
-            work.groupby(["experience_variant_label", "variant_user_pseudo_id"], as_index=False)[kpi]
-            .sum()
-        )
+        work = per_visitor
         unit = AnalysisUnit.PER_VISITOR
 
     config = ContinuousMetricConfig(


### PR DESCRIPTION
## Summary

Two more issues found reviewing the current state of the Automation wizard, after the last two rounds of fixes:

- **The continuous RPV double-counting fix was incomplete.** It only patched `run_continuous_analysis`'s internal handling. Three other sites in `automation.py` independently re-derived stats from the same raw, one-row-per-order `df_continuous` and still assumed one row = one visitor: the Step 2 "Continuous data" preview table (shown before any analysis runs), the `total_visitors` fallback, and `daily_visitors_continuous` — the figure that scales *every* Continuous "effect on revenue" projection, for both RPV and RPT. Confirmed with a synthetic repeat purchaser that `daily_visitors_continuous` came out 33% too high, directly inflating the revenue projection even though the significance-test fix was already correct.

  Added `collapse_to_per_visitor` as the single shared place a raw continuous fetch gets collapsed to one row per (variant, visitor), summing revenue across repeat purchasers. `run_continuous_analysis`'s RPV branch and `visitor_counts` derivation now both come from this same collapse instead of separate logic, and all three `automation.py` sites compute `per_visitor_continuous` once and build every downstream stat from it instead of raw row counts.

- **Stale binomial/continuous data could silently carry forward.** `df_binomial`/`df_continuous` were read from session state unconditionally in Step 1, regardless of the current `want_binomial`/`want_continuous` checkbox state. Fetch both, go back, uncheck one (e.g. after seeing its scan cost) and re-fetch just the other, and the unchecked one's stale result still silently carried into Step 2/3 — possibly from a since-changed experiment ID, date range, or filter if those were also edited in between. Now gated on the current checkbox state.

## Test plan

- [x] `py_compile` clean on both touched files
- [x] `collapse_to_per_visitor` and every downstream site (Step 2 preview table, `total_visitors`, `daily_visitors_continuous`, `run_continuous_analysis` RPV/RPT) verified end-to-end against the real FOE engine with a synthetic repeat purchaser — correct visitor counts and revenue-per-visitor throughout, RPT's per-order granularity unaffected
- [x] Confirmed the `want_binomial`/`want_continuous` gate is in place via source inspection
- [x] Manual click-through in the Streamlit app not performed (no live BigQuery/Airtable/Gemini credentials in this environment)