### PR TITLE
Fix stale pretest data surviving an unchecked pre-test fetch

### DIFF
--- a/pages/automation.py
+++ b/pages/automation.py
@@ -803,6 +803,19 @@ def _render_stage_configure():
             st.session_state["auto_variation"] = variation
             st.session_state["auto_results"] = results
             st.session_state["auto_revenue_source"] = revenue_source
+
+            # A previously-generated AI conclusion (Step 4) describes a
+            # specific set of results -- nothing else invalidates it, so
+            # without this it would silently survive a re-run with different
+            # settings (confidence level, active methods, revenue source,
+            # ...) and get re-attached to a new payload with different
+            # numbers, with no indication the text no longer describes them.
+            # Dropping it here forces Step 4 to start from "not generated
+            # yet" after any change, rather than an explicit regenerate being
+            # something the user has to remember to do on their own.
+            st.session_state.pop("auto_ai_conclusion", None)
+            st.session_state.pop("auto_ai_include", None)
+
             st.session_state["auto_stage"] = 3
             st.rerun()
 

--- a/pages/automation.py
+++ b/pages/automation.py
@@ -420,8 +420,16 @@ def _render_stage_fetch():
         except ValueError:
             st.session_state["auto_runtime_days"] = 1
 
-        df_pretest = st.session_state.get("auto_pretest_result")
-        df_pretest_daily = st.session_state.get("auto_pretest_daily_result")
+        # Gated on the current want_pretest checkbox state, same reason as the
+        # want_binomial/want_continuous gate above: without it, unchecking
+        # "Fetch pre-test baseline data" after a previous fetch (e.g. going
+        # back and deciding not to use it this run) wouldn't actually drop
+        # the stale result -- the elif below would still pick it up and build
+        # auto_pretest_meta from it, silently keeping Pre-Test Analysis
+        # available with baseline data from a possibly different
+        # weeks/KPI/experiment configuration.
+        df_pretest = st.session_state.get("auto_pretest_result") if want_pretest else None
+        df_pretest_daily = st.session_state.get("auto_pretest_daily_result") if want_pretest else None
         st.session_state["auto_df_pretest"] = df_pretest
         use_seasonal = want_pretest and bool(st.session_state.get("autofetch_pretest_seasonal", False))
         kpi_choice = st.session_state.get("autofetch_pretest_kpi", "Transactions (purchases)")

--- a/utility/automation_engine.py
+++ b/utility/automation_engine.py
@@ -233,8 +233,22 @@ def run_bayesian_analysis(
     engine = BayesianEngine()
     prob_result = engine.run_probability_analysis(data, n_samples=n_samples)[0]
 
+    # BayesianEngine._sample_aov draws AOV samples via
+    # np.log(mean_aov) -- an AOV of exactly 0.0 (VariantData.aov defaults to
+    # 0.0 when a variant has zero conversions, e.g. very early in a test)
+    # sends that straight to log(0) = -inf, raising a RuntimeWarning on every
+    # such run. It doesn't crash -- exp(-inf) underflows cleanly to 0.0,
+    # which is the right degenerate answer (no order data to model an AOV
+    # distribution from) -- but relying on float underflow instead of an
+    # explicit guard is fragile. Clamped to a negligible epsilon instead:
+    # indistinguishable from 0 in any reported figure (every downstream
+    # value rounds to cents) but keeps log() finite.
+    _AOV_EPSILON = 1e-6
     biz_case = BusinessCaseInput(
-        aovs={control.label: control.aov, variation.label: variation.aov},
+        aovs={
+            control.label: control.aov or _AOV_EPSILON,
+            variation.label: variation.aov or _AOV_EPSILON,
+        },
         runtime_days=runtime_days,
         projection_period=projection_days,
     )


### PR DESCRIPTION
## Summary

Three bugs found reviewing the automation wizard:

- **Stale pretest data.** `df_pretest`/`df_pretest_daily` were read from session state unconditionally at the Step 1 → Step 2 transition — gated on the seasonal-specific branch (`use_seasonal`, itself tied to `want_pretest`) but not on `want_pretest` for the flat/aggregate path. Fetch pretest baseline data → go to Step 2 → go back and uncheck "Fetch pre-test baseline data" → continue, and the stale result was still picked up, keeping Pre-Test Analysis available with baseline data from a possibly different weeks/KPI/experiment configuration despite the checkbox now saying otherwise. Gated both reads on `want_pretest`, mirroring the `want_binomial`/`want_continuous` gate from #103.

- **Stale AI conclusion.** `auto_ai_conclusion` (Step 4's Gemini-generated text) was written once and read back unconditionally forever after — nothing invalidated it. Generate a conclusion, go back to Step 2, change something (confidence level, active methods, revenue source, anything), run analysis again — the old text, describing the old numbers, is still shown at Step 4 with "Include this conclusion" defaulted to checked, silently reattaching a narrative to a payload with different numbers than the one it was actually written about. Now cleared whenever "Run analysis" produces new results.

- **Bayesian log(0) on a zero-AOV variant.** A variant with zero conversions this early in a test defaults to AOV=0.0. `BayesianEngine._sample_aov` computes `np.log(mean_aov)`, so `log(0) = -inf`, raising a `RuntimeWarning` on every such run (confirmed it doesn't crash the wizard — `exp(-inf)` underflows cleanly to 0.0, the correct degenerate answer — but it's relying on float-underflow behavior rather than an explicit guard, and pollutes server logs). Clamped AOV to a negligible epsilon before building `BusinessCaseInput`; verified with warnings promoted to exceptions that this fully silences it, and that normal (non-zero-AOV) results are numerically unaffected.

## Test plan

- [x] `py_compile` clean on all three commits
- [x] Pretest fix: traced all four `want_pretest`/`use_seasonal` state combinations by hand
- [x] AI-conclusion fix: confirmed `auto_ai_conclusion`/`auto_ai_include` are the only state driving Step 4's display/payload attachment
- [x] Bayesian fix: verified against the real FOE engine with `warnings.filterwarnings("error")` — zero-AOV case raises nothing after the fix (raised `RuntimeWarning` before it); a normal non-zero-AOV case's result is unaffected by the epsilon clamp
- [x] Manual click-through in the Streamlit app not performed (no live BigQuery/Gemini credentials in this environment)