### PR TITLE
Fix silent Control/Variation swap on re-detecting variants for a different experiment

### DIFF
--- a/utility/bq_ui_components.py
+++ b/utility/bq_ui_components.py
@@ -332,11 +332,32 @@ def render_variant_inputs(
                     with col_str:
                         st.text(variant_str)
                     with col_sel:
+                        # Scoped by exp_id + the variant string itself, not
+                        # just position (vi) -- _label_opts never changes, so
+                        # a position-scoped key has no "options changed under
+                        # a stale key" fallback to even warn on: switching to
+                        # a different experiment ID and re-detecting (e.g.
+                        # via "Back to data fetch") silently keeps whatever
+                        # label was assigned at that same position before,
+                        # attached to whatever string now happens to sit
+                        # there. If the two experiments' variant strings
+                        # don't happen to sort in the same relative order,
+                        # that silently swaps which string means Control (A)
+                        # vs Variation (B) -- confirmed via a live Streamlit
+                        # test, with labels_present still coming out exactly
+                        # {"A", "B"} either way, so the existing "no A
+                        # assigned" guard below never catches it. Scoping by
+                        # exp_id + variant_str instead means a genuinely new
+                        # experiment's detection always starts from fresh
+                        # defaults, while re-detecting the SAME experiment
+                        # (e.g. after widening the date range) still
+                        # correctly remembers prior manual assignments for
+                        # strings it already knows about.
                         assigned = st.selectbox(
                             "Label",
                             options=_label_opts,
                             index=default_idx,
-                            key=f"{key_prefix}_exp_{exp_idx}_assign_{vi}",
+                            key=f"{key_prefix}_exp_{exp_idx}_{exp_id}_assign_{variant_str}",
                             label_visibility="collapsed",
                         )
 


### PR DESCRIPTION
## Summary

`render_variant_inputs`'s per-variant label selectbox was keyed only by list position (`key=f"{key_prefix}_exp_{exp_idx}_assign_{vi}"`), never by the variant string itself or the experiment ID that produced it. `_label_opts` is a fixed, unchanging list, so there's no "options changed under a stale key" fallback to even warn on — Streamlit just keeps whatever was assigned at that position indefinitely.

Confirmed via a live Streamlit `AppTest`: detect variants for experiment X (`["expX_control", "expX_treatment"]`, alphabetically sorted so defaults correctly land Control→A, Treatment→B). Go back to Step 1, switch to experiment Y, re-detect — Y's variant strings happen to sort in the opposite relative order (`["expY_treatment", "expY_control"]`, entirely plausible since ordering comes from each testing tool's own string/ID scheme). Result, with **zero manual interaction**:

```
expY_treatment -> A — Control
expY_control   -> B
```

A straight swap. `labels_present` still comes out exactly `{"A", "B"}`, so automation.py's own `labels_present != {'A','B'}` guard passes clean and never catches it. Every downstream number — uplift direction, significance, revenue projection, ship/hold recommendation — would be built on an inverted premise, with no error and no visual cue.

Reachable through the app's own supported flow: fetch → "Back to data fetch" → change the Experiment ID → re-detect → continue. No "Start over" needed (that already clears this state correctly).

## Fix

Scoped the key by `exp_id` + the variant string itself instead of position. Verified two properties with `AppTest`:
- Switching to a different experiment now gets genuinely fresh defaults — no silent inheritance.
- Re-detecting the *same* experiment (e.g. after widening the date range) still correctly remembers prior manual assignments for strings it already knows about.

`render_variant_inputs` is shared by `data_export.py`'s multi-experiment mode too, which loops through several experiment slots each with their own auto-detect — same fix covers that path as well.

## Test plan

- [x] `py_compile` clean on `bq_ui_components.py`, `automation.py`, and `data_export.py` (both consumers)
- [x] Live `AppTest` repro confirming the swap on the unpatched code
- [x] Live `AppTest` confirming the fix: fresh defaults on experiment switch, preserved manual choices on same-experiment re-detect
- [ ] Manual click-through in the Streamlit app not performed (no live BigQuery credentials in this environment)