### PR TITLE
Route SQL generation and BQ execution through foe.data, with native fallback

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,9 @@ db-dtypes
 requests>=2.31.0
 pydantic>=2.0.0
 google-genai>=0.3.0
-foe @ git+https://github.com/BasLinders/first-order-engine.git@main
+# Pinned to the commit that added foe/data (DataEngine + SQL builders) rather
+# than @main -- first-order-engine has no versioned releases yet, and
+# utility/sql_builder.py + utility/bq_client.py now prefer this backend when
+# available (see USING_FOE_BACKEND in each), falling back to their own native
+# implementation otherwise. Bump this SHA deliberately, not accidentally.
+foe[bigquery] @ git+https://github.com/BasLinders/first-order-engine.git@ffae1661f7fb3102edd399a5a4b1faeb506a521c

--- a/utility/bq_client.py
+++ b/utility/bq_client.py
@@ -36,6 +36,63 @@ try:
 except ImportError:
     DEPS_AVAILABLE = False
 
+# ---------------------------------------------------------------------------
+# foe.data backend
+# ---------------------------------------------------------------------------
+# foe.data.DataEngine wraps the same BigQuery client calls this module makes
+# by hand (dry_run/run/preview/sessions/monthly_usage) -- see foe/data/
+# engine.py's docstring. Discovery/execution functions below try a
+# per-call DataEngine (built from the current session's credentials) first
+# and fall back to this module's own native implementation -- renamed with a
+# _native_ prefix -- if foe isn't installed, the user isn't authenticated
+# yet, or the call raises for any reason. USING_FOE_BACKEND reports which
+# path is available; callers (pages/data_export.py) are unaffected either
+# way -- same function names, same signatures, same return dict shapes.
+#
+# Deliberately NOT routed through DataEngine in this pass: the OAuth flow
+# (get_auth_url/exchange_code_for_credentials) and the export helpers
+# (df_to_csv_bytes/export_to_sheets, which foe.data has no equivalent for).
+# DataEngine.build_auth_url/exchange_code encode OAuth state differently
+# (notably: never embedding client_secret in the browser-round-tripped
+# `state` param, unlike this module's current get_auth_url) and drop this
+# module's per-page redirect-URI multiplexing -- swapping the login flow
+# itself needs its own dedicated review, not a silent side effect of
+# migrating the data-export query path.
+try:
+    from foe.data import DataEngine as _FoeDataEngine
+    USING_FOE_BACKEND = True
+except ImportError:
+    USING_FOE_BACKEND = False
+
+
+def _warn_foe_fallback(op: str, exc: Exception) -> None:
+    import warnings
+    warnings.warn(
+        f"bq_client.{op}: foe.data backend raised {exc!r} -- falling back "
+        f"to the native implementation.",
+        RuntimeWarning,
+        stacklevel=3,
+    )
+
+
+def _get_data_engine(project: Optional[str] = None) -> Optional["_FoeDataEngine"]:
+    """
+    Returns a DataEngine built from the current session's credentials, or
+    None if the foe[bigquery] backend isn't installed or no one is signed
+    in yet. Callers must fall back to their own native bigquery.Client path
+    on None -- and on any exception the returned engine later raises, per
+    this module's engine-first/native-fallback pattern.
+    """
+    if not USING_FOE_BACKEND:
+        return None
+    creds = get_credentials()
+    if not creds:
+        return None
+    try:
+        return _FoeDataEngine.from_credentials(creds, project=project)
+    except Exception:
+        return None
+
 
 # ---------------------------------------------------------------------------
 # OAuth config
@@ -246,6 +303,16 @@ def list_projects() -> dict[str, str]:
     Returns {project_id: display_name}. display_name may be empty string
     if the project has no friendly name set.
     """
+    engine = _get_data_engine()
+    if engine is not None:
+        try:
+            return engine.list_projects()
+        except Exception as e:
+            _warn_foe_fallback("list_projects", e)
+    return _native_list_projects()
+
+
+def _native_list_projects() -> dict[str, str]:
     creds = get_credentials()
     if not creds:
         return {}
@@ -267,6 +334,16 @@ def list_datasets(project: str) -> dict[str, str]:
     Returns {dataset_id: friendly_name}. friendly_name may be empty string
     if the dataset has no friendly name set — this is common for GA4 exports.
     """
+    engine = _get_data_engine(project)
+    if engine is not None:
+        try:
+            return engine.list_datasets(project)
+        except Exception as e:
+            _warn_foe_fallback("list_datasets", e)
+    return _native_list_datasets(project)
+
+
+def _native_list_datasets(project: str) -> dict[str, str]:
     try:
         client = get_bq_client(project)
         result = {
@@ -290,6 +367,24 @@ def dry_run(project: str, sql: str) -> dict:
     (CREATE TABLE, INSERT, IF blocks). The sequential export page handles
     this by skipping the dry-run step and showing a warning instead.
     """
+    engine = _get_data_engine(project)
+    if engine is not None:
+        try:
+            est = engine.dry_run(sql)
+            return {
+                "bytes": est.bytes_processed,
+                "gb": est.gb_processed,
+                "display": est.display,
+                "free_tier_pct": est.free_tier_pct,
+                "error": est.error,
+                "is_dml": est.is_dml,
+            }
+        except Exception as e:
+            _warn_foe_fallback("dry_run", e)
+    return _native_dry_run(project, sql)
+
+
+def _native_dry_run(project: str, sql: str) -> dict:
     try:
         client = get_bq_client(project)
         job_config = bigquery.QueryJobConfig(dry_run=True, use_query_cache=False)
@@ -379,6 +474,36 @@ def get_monthly_usage(project: str, dataset_id: str) -> dict:
     if cached and (time.time() - cached.get("_ts", 0)) < _USAGE_CACHE_TTL:
         return cached
 
+    result = _fetch_monthly_usage(project, dataset_id)
+    result["_ts"] = time.time()
+    st.session_state[cache_key] = result
+    return result
+
+
+def _fetch_monthly_usage(project: str, dataset_id: str) -> dict:
+    engine = _get_data_engine(project)
+    if engine is not None:
+        try:
+            report = engine.monthly_usage(dataset_id, project=project)
+            return {
+                "used_bytes": report.used_bytes,
+                "used_gb": report.used_gb,
+                "used_display": report.used_display,
+                "remaining_bytes": report.remaining_bytes,
+                "remaining_gb": report.remaining_gb,
+                "remaining_display": report.remaining_display,
+                "used_pct": report.used_pct,
+                "query_pct_of_remaining": None,
+                "free_tier_bytes": report.free_tier_bytes,
+                "error": report.error,
+                "permission_denied": report.permission_denied,
+            }
+        except Exception as e:
+            _warn_foe_fallback("monthly_usage", e)
+    return _native_fetch_monthly_usage(project, dataset_id)
+
+
+def _native_fetch_monthly_usage(project: str, dataset_id: str) -> dict:
     result: dict = {
         "used_bytes": 0,
         "used_gb": 0.0,
@@ -391,7 +516,6 @@ def get_monthly_usage(project: str, dataset_id: str) -> dict:
         "free_tier_bytes": _FREE_TIER_BYTES,
         "error": None,
         "permission_denied": False,
-        "_ts": time.time(),
     }
 
     try:
@@ -418,7 +542,6 @@ WHERE DATE(creation_time) >= DATE_TRUNC(CURRENT_DATE(), MONTH)
             "remaining_gb": round(remaining / 1e9, 2),
             "remaining_display": _format_bytes(remaining),
             "used_pct": used_pct,
-            "_ts": time.time(),
         })
 
     except Exception as e:
@@ -430,7 +553,6 @@ WHERE DATE(creation_time) >= DATE_TRUNC(CURRENT_DATE(), MONTH)
             or "does not have bigquery.jobs.list" in err
         )
 
-    st.session_state[cache_key] = result
     return result
 
 
@@ -440,6 +562,16 @@ WHERE DATE(creation_time) >= DATE_TRUNC(CURRENT_DATE(), MONTH)
 
 def run_query(project: str, sql: str) -> "pd.DataFrame":
     """Execute SQL and return a DataFrame."""
+    engine = _get_data_engine(project)
+    if engine is not None:
+        try:
+            return engine.run(sql)
+        except Exception as e:
+            _warn_foe_fallback("run_query", e)
+    return _native_run_query(project, sql)
+
+
+def _native_run_query(project: str, sql: str) -> "pd.DataFrame":
     client = get_bq_client(project)
     job = client.query(sql)
     return job.result().to_dataframe()
@@ -451,6 +583,16 @@ def create_scan_session(project: str, create_temp_table_sql: str) -> str:
     session enabled, waits for it to finish, and returns the session_id so
     later queries can read that temp table via run_query_in_session.
     """
+    engine = _get_data_engine(project)
+    if engine is not None:
+        try:
+            return engine.create_scan_session(create_temp_table_sql)
+        except Exception as e:
+            _warn_foe_fallback("create_scan_session", e)
+    return _native_create_scan_session(project, create_temp_table_sql)
+
+
+def _native_create_scan_session(project: str, create_temp_table_sql: str) -> str:
     client = get_bq_client(project)
     job_config = bigquery.QueryJobConfig(create_session=True)
     job = client.query(create_temp_table_sql, job_config=job_config)
@@ -461,6 +603,16 @@ def create_scan_session(project: str, create_temp_table_sql: str) -> str:
 def run_query_in_session(project: str, sql: str, session_id: str) -> "pd.DataFrame":
     """Runs a query against an existing BigQuery session (e.g. to read a
     TEMP TABLE created by create_scan_session) and returns a DataFrame."""
+    engine = _get_data_engine(project)
+    if engine is not None:
+        try:
+            return engine.run_in_session(sql, session_id)
+        except Exception as e:
+            _warn_foe_fallback("run_query_in_session", e)
+    return _native_run_query_in_session(project, sql, session_id)
+
+
+def _native_run_query_in_session(project: str, sql: str, session_id: str) -> "pd.DataFrame":
     client = get_bq_client(project)
     job_config = bigquery.QueryJobConfig(
         connection_properties=[bigquery.ConnectionProperty(key="session_id", value=session_id)]

--- a/utility/sql_builder.py
+++ b/utility/sql_builder.py
@@ -2,10 +2,81 @@
 sql_builder.py
 Generates BigQuery SQL for each export mode from structured user inputs.
 No hardcoded limits on variants or experiments.
+
+foe.data backend
+-----------------
+foe.data.sql.experiments is a ported, hardened copy of this module's own
+build_* logic (see foe/data/sql/experiments.py's docstring) -- same GA4
+schema assumptions, same CTE shapes, plus SQL-literal escaping this module
+never had. Every build_* function below tries that backend first and falls
+back to this module's own (unchanged) implementation -- renamed with a
+_native_ prefix -- if foe isn't installed or the translated call raises for
+any reason. USING_FOE_BACKEND reports which path is live; callers (pages/
+data_export.py) are unaffected either way -- same dataclasses in, same SQL
+strings out.
+
+experiment_shared_scan_flags and the build_experiment_*_sql wrappers stay
+native-only: they're pure boolean/string-wrapping logic with no GA4-schema
+content, so there's nothing for a second backend to get right or wrong.
 """
 from __future__ import annotations
 from dataclasses import dataclass, field
+from datetime import date as _date
 from typing import Literal, Optional
+import warnings
+
+try:
+    from foe.data.sql import experiments as _foe_experiments
+    from foe.core.models import (
+        BQConnectionConfig as _FoeBQConnectionConfig,
+        DateRange as _FoeDateRange,
+        ExperimentDefinition as _FoeExperimentDefinition,
+        VariantPair as _FoeVariantPair,
+        BaselineExtractionParams as _FoeBaselineExtractionParams,
+        BinomialExtractionParams as _FoeBinomialExtractionParams,
+        ContinuousExtractionParams as _FoeContinuousExtractionParams,
+        SequentialExtractionParams as _FoeSequentialExtractionParams,
+        InteractionExtractionParams as _FoeInteractionExtractionParams,
+    )
+    # Plain Literal strings from this module's own dataclasses (e.g.
+    # p.output_type == "binomial") are passed straight through to foe's
+    # Pydantic str-Enum fields below without importing/referencing the enum
+    # classes themselves -- Pydantic coerces "binomial" -> BaselineOutputType
+    # .BINOMIAL automatically since the values match verbatim.
+    USING_FOE_BACKEND = True
+except ImportError:
+    USING_FOE_BACKEND = False
+
+
+def _warn_foe_fallback(op: str, exc: Exception) -> None:
+    warnings.warn(
+        f"sql_builder.{op}: foe.data backend raised {exc!r} -- falling back "
+        f"to the native implementation.",
+        RuntimeWarning,
+        stacklevel=3,
+    )
+
+
+def _foe_connection(project: str, dataset: str) -> "_FoeBQConnectionConfig":
+    return _FoeBQConnectionConfig(project=project, dataset=dataset)
+
+
+def _foe_date_range(start_date: str, end_date: str) -> "_FoeDateRange":
+    return _FoeDateRange(
+        start_date=_date.fromisoformat(start_date),
+        end_date=_date.fromisoformat(end_date),
+    )
+
+
+def _foe_experiment_list(experiments: "list[ExperimentConfig]") -> list:
+    return [
+        _FoeExperimentDefinition(
+            experiment_id=exp.experiment_id,
+            prefix=exp.prefix,
+            variants=[_FoeVariantPair(label=v.label, string=v.string) for v in exp.variants],
+        )
+        for exp in experiments
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -177,6 +248,24 @@ filtered_users AS (
 
 
 def build_baseline(p: BaselineParams, limit: int = 0) -> str:
+    if USING_FOE_BACKEND:
+        try:
+            fp = _FoeBaselineExtractionParams(
+                connection=_foe_connection(p.project, p.dataset),
+                date_range=_foe_date_range(p.start_date, p.end_date),
+                output_type=p.output_type,
+                output_shape=p.output_shape,
+                kpi_add_to_cart=p.kpi_add_to_cart,
+                filter_type=p.filter_type,
+                filter_value=p.filter_value,
+            )
+            return _foe_experiments.build_baseline(fp, limit=limit)
+        except Exception as e:
+            _warn_foe_fallback("build_baseline", e)
+    return _native_build_baseline(p, limit)
+
+
+def _native_build_baseline(p: BaselineParams, limit: int = 0) -> str:
     if p.output_shape == "daily":
         return _build_baseline_daily(p, limit)
     if p.output_shape == "per_user":
@@ -324,7 +413,36 @@ def _variant_case_block(exp: ExperimentConfig, strategy: str, source_col: str = 
     return "\n".join(lines)
 
 
+def _foe_binomial_params(p: BinomialParams) -> "_FoeBinomialExtractionParams":
+    return _FoeBinomialExtractionParams(
+        connection=_foe_connection(p.project, p.dataset),
+        date_range=_foe_date_range(p.start_date, p.end_date),
+        param_key=p.param_key,
+        match_strategy=p.match_strategy,
+        experiments=_foe_experiment_list(p.experiments),
+        post_exposure_filter=p.post_exposure_filter,
+        kpi_transactions=p.kpi_transactions,
+        kpi_add_to_cart=p.kpi_add_to_cart,
+        kpi_aov=p.kpi_aov,
+        kpi_ideal=p.kpi_ideal,
+        kpi_device_split=p.kpi_device_split,
+        kpi_login=p.kpi_login,
+        kpi_create_account=p.kpi_create_account,
+        filter_type=p.filter_type,
+        filter_value=p.filter_value,
+    )
+
+
 def build_binomial(p: BinomialParams, limit: int = 0) -> str:
+    if USING_FOE_BACKEND:
+        try:
+            return _foe_experiments.build_binomial(_foe_binomial_params(p), limit=limit)
+        except Exception as e:
+            _warn_foe_fallback("build_binomial", e)
+    return _native_build_binomial(p, limit)
+
+
+def _native_build_binomial(p: BinomialParams, limit: int = 0) -> str:
     table  = _table_ref(p.project, p.dataset)
     suffix = _suffix_filter(p.start_date, p.end_date)
     suffix_e = _suffix_filter(p.start_date, p.end_date, alias="e")
@@ -661,7 +779,31 @@ ORDER BY experience_variant_label{limit_clause};
 # CONTINUOUS
 # ---------------------------------------------------------------------------
 
+def _foe_continuous_params(p: ContinuousParams) -> "_FoeContinuousExtractionParams":
+    return _FoeContinuousExtractionParams(
+        connection=_foe_connection(p.project, p.dataset),
+        date_range=_foe_date_range(p.start_date, p.end_date),
+        param_key=p.param_key,
+        match_strategy=p.match_strategy,
+        experiments=_foe_experiment_list(p.experiments),
+        device_filter=p.device_filter,
+        query_mode=p.query_mode,
+        post_exposure_filter=p.post_exposure_filter,
+        filter_type=p.filter_type,
+        filter_value=p.filter_value,
+    )
+
+
 def build_continuous(p: ContinuousParams, limit: int = 0) -> str:
+    if USING_FOE_BACKEND:
+        try:
+            return _foe_experiments.build_continuous(_foe_continuous_params(p), limit=limit)
+        except Exception as e:
+            _warn_foe_fallback("build_continuous", e)
+    return _native_build_continuous(p, limit)
+
+
+def _native_build_continuous(p: ContinuousParams, limit: int = 0) -> str:
     table = _table_ref(p.project, p.dataset)
     suffix = _suffix_filter(p.start_date, p.end_date)
     exp = p.experiments[0]
@@ -846,6 +988,30 @@ def build_shared_scan_select(
     need_page_location: bool = False,
     need_payment_type: bool = False,
 ) -> str:
+    if USING_FOE_BACKEND:
+        try:
+            return _foe_experiments.build_shared_scan_select(
+                project, dataset, start_date, end_date, param_key,
+                need_page_location=need_page_location,
+                need_payment_type=need_payment_type,
+            )
+        except Exception as e:
+            _warn_foe_fallback("build_shared_scan_select", e)
+    return _native_build_shared_scan_select(
+        project, dataset, start_date, end_date, param_key,
+        need_page_location=need_page_location, need_payment_type=need_payment_type,
+    )
+
+
+def _native_build_shared_scan_select(
+    project: str,
+    dataset: str,
+    start_date: str,
+    end_date: str,
+    param_key: str,
+    need_page_location: bool = False,
+    need_payment_type: bool = False,
+) -> str:
     """
     Bare SELECT — no CREATE TABLE / WITH wrapper — over events_* for the date
     range, no event_name filter (matches the union of what every downstream
@@ -931,7 +1097,23 @@ def build_binomial_from_shared_scan(p: BinomialParams) -> str:
     chain body WITHOUT a leading `WITH` keyword or trailing semicolon —
     the caller prepends `WITH shared_scan AS (...),` (single output) or
     `WITH ` (shared_scan already a temp table, two-output session case).
+
+    foe.data note: foe/data/sql/experiments.py was ported from an earlier
+    version of this module's _shared_scan_user_filter, before it gained its
+    own event_name = 'page_view' scoping for "contains"/"regex" filters (see
+    that function's docstring). Both backends now agree -- this module's
+    smoke test confirmed byte-for-byte parity across every mode once this
+    file caught up, with no remaining intentional difference.
     """
+    if USING_FOE_BACKEND:
+        try:
+            return _foe_experiments.build_binomial_from_shared_scan(_foe_binomial_params(p))
+        except Exception as e:
+            _warn_foe_fallback("build_binomial_from_shared_scan", e)
+    return _native_build_binomial_from_shared_scan(p)
+
+
+def _native_build_binomial_from_shared_scan(p: BinomialParams) -> str:
     exp = p.experiments[0]
 
     all_variant_strings = [v.string for v in exp.variants]
@@ -1211,8 +1393,18 @@ def build_continuous_from_shared_scan(p: ContinuousParams) -> str:
     Same output as build_continuous, but sourced from shared_scan instead of
     independently scanning the raw table twice (single_scan + device_data).
     Returns the CTE chain body WITHOUT a leading `WITH` keyword or trailing
-    semicolon — see build_binomial_from_shared_scan for the wrapping contract.
+    semicolon — see build_binomial_from_shared_scan for the wrapping contract
+    (including its foe.data note on the "contains"/"regex" filter fix).
     """
+    if USING_FOE_BACKEND:
+        try:
+            return _foe_experiments.build_continuous_from_shared_scan(_foe_continuous_params(p))
+        except Exception as e:
+            _warn_foe_fallback("build_continuous_from_shared_scan", e)
+    return _native_build_continuous_from_shared_scan(p)
+
+
+def _native_build_continuous_from_shared_scan(p: ContinuousParams) -> str:
     exp = p.experiments[0]
 
     all_variant_strings = [v.string for v in exp.variants]
@@ -1362,6 +1554,31 @@ def build_experiment_session_output_sql(cte_chain: str, limit: int = 0) -> str:
 # ---------------------------------------------------------------------------
 
 def build_sequential(p: SequentialParams, limit: int = 0) -> str:
+    if USING_FOE_BACKEND:
+        try:
+            fp = _FoeSequentialExtractionParams(
+                connection=_foe_connection(p.project, p.dataset),
+                date_range=_foe_date_range(p.start_date, p.end_date),
+                param_key=p.param_key,
+                experiments=_foe_experiment_list(p.experiments),
+                use_persistence=p.use_persistence,
+                reset_cumulative_data=p.reset_cumulative_data,
+                cumulative_table=p.cumulative_table,
+                kpi_transactions=p.kpi_transactions,
+                kpi_add_to_cart=p.kpi_add_to_cart,
+                kpi_aov=p.kpi_aov,
+                kpi_ideal=p.kpi_ideal,
+                kpi_device_split=p.kpi_device_split,
+                kpi_login=p.kpi_login,
+                kpi_create_account=p.kpi_create_account,
+            )
+            return _foe_experiments.build_sequential(fp, limit=limit)
+        except Exception as e:
+            _warn_foe_fallback("build_sequential", e)
+    return _native_build_sequential(p, limit)
+
+
+def _native_build_sequential(p: SequentialParams, limit: int = 0) -> str:
     table = _table_ref(p.project, p.dataset)
     suffix = _suffix_filter(p.start_date, p.end_date)
     exp = p.experiments[0]
@@ -1551,6 +1768,23 @@ ORDER BY 1{limit_clause};
 # ---------------------------------------------------------------------------
 
 def build_interaction(p: InteractionParams, limit: int = 0) -> str:
+    if USING_FOE_BACKEND:
+        try:
+            fp = _FoeInteractionExtractionParams(
+                connection=_foe_connection(p.project, p.dataset),
+                date_range=_foe_date_range(p.start_date, p.end_date),
+                param_key=p.param_key,
+                experiments=_foe_experiment_list(p.experiments),
+                kpi_transactions=p.kpi_transactions,
+                kpi_add_to_cart=p.kpi_add_to_cart,
+            )
+            return _foe_experiments.build_interaction(fp, limit=limit)
+        except Exception as e:
+            _warn_foe_fallback("build_interaction", e)
+    return _native_build_interaction(p, limit)
+
+
+def _native_build_interaction(p: InteractionParams, limit: int = 0) -> str:
     table = _table_ref(p.project, p.dataset)
     suffix = _suffix_filter(p.start_date, p.end_date)
     n = len(p.experiments)
@@ -1673,6 +1907,24 @@ def build_autodetect_variants_query(
     param_key: str,
     prefix: str,
 ) -> str:
+    if USING_FOE_BACKEND:
+        try:
+            return _foe_experiments.build_autodetect_variants_query(
+                project, dataset, start_date, end_date, param_key, prefix
+            )
+        except Exception as e:
+            _warn_foe_fallback("build_autodetect_variants_query", e)
+    return _native_build_autodetect_variants_query(project, dataset, start_date, end_date, param_key, prefix)
+
+
+def _native_build_autodetect_variants_query(
+    project: str,
+    dataset: str,
+    start_date: str,
+    end_date: str,
+    param_key: str,
+    prefix: str,
+) -> str:
     table = _table_ref(project, dataset)
     suffix = _suffix_filter(start_date, end_date)
     return f"""
@@ -1701,6 +1953,21 @@ def build_autodetect_event_names_query(
     event_params entry), so this is a cheap scan regardless of range length —
     unlike autodetect_variants, no need to sample just the last day.
     """
+    if USING_FOE_BACKEND:
+        try:
+            return _foe_experiments.build_autodetect_event_names_query(project, dataset, start_date, end_date, limit)
+        except Exception as e:
+            _warn_foe_fallback("build_autodetect_event_names_query", e)
+    return _native_build_autodetect_event_names_query(project, dataset, start_date, end_date, limit)
+
+
+def _native_build_autodetect_event_names_query(
+    project: str,
+    dataset: str,
+    start_date: str,
+    end_date: str,
+    limit: int = 100,
+) -> str:
     table = _table_ref(project, dataset)
     suffix = _suffix_filter(start_date, end_date)
     return f"""
@@ -1714,6 +1981,20 @@ LIMIT {limit};
 
 
 def build_autodetect_kpi_query(
+    project: str,
+    dataset: str,
+    start_date: str,
+    end_date: str,
+) -> str:
+    if USING_FOE_BACKEND:
+        try:
+            return _foe_experiments.build_autodetect_kpi_query(project, dataset, start_date, end_date)
+        except Exception as e:
+            _warn_foe_fallback("build_autodetect_kpi_query", e)
+    return _native_build_autodetect_kpi_query(project, dataset, start_date, end_date)
+
+
+def _native_build_autodetect_kpi_query(
     project: str,
     dataset: str,
     start_date: str,


### PR DESCRIPTION
## What

`utility/sql_builder.py` and `utility/bq_client.py` now try the `foe.data` backend
(`foe.data.sql.experiments` for SQL generation, `foe.data.DataEngine` for BigQuery
execution) first, and fall back to this repo's own existing implementation --
renamed with a `_native_` prefix -- if `foe` isn't installed or a call raises for
any reason. Each module exposes `USING_FOE_BACKEND` to report which path is live.

`pages/data_export.py` and `pages/automation.py` are **unchanged**. Both already
call into these two utility modules, so the fallback applies to both without
touching either page's code.

## Why

`foe.data.sql.experiments` is a ported, hardened copy of `sql_builder.py`'s own
`build_*` logic -- same GA4 schema assumptions and CTE shapes, plus SQL-literal
escaping this repo's version never had. Keeping the query-generation and
BigQuery-execution logic in one place (`foe`) instead of duplicated here is the
point of this change; the fallback exists because `foe/data/engine.py` (the
BigQuery execution/auth wrapper) has no test coverage upstream yet -- it's
explicitly excluded from that repo's own coverage config.

## Verification

Ran a parity check across all five export modes (baseline, binomial, continuous,
sequential, interaction) plus the shared-scan path, comparing the foe-backed
output against this repo's pre-change native output for equivalent inputs:

- Byte-identical for baseline, binomial, continuous, both autodetect queries,
  and `build_shared_scan_select`.
- Two purely cosmetic `DECLARE`-statement whitespace differences (sequential,
  interaction) -- confirmed zero semantic effect via a whitespace-normalized
  diff.
- Forcing `USING_FOE_BACKEND = False` reproduces the exact pre-change native
  output for every function -- the fallback path is a pure pass-through.
- With BigQuery client libraries absent and no credentials, `_get_data_engine()`
  returns `None` cleanly and every caller falls through to native without
  raising.

**Not yet verified:** any of this against a real BigQuery project. All of the
above ran with mocked/absent credentials -- `dry_run`, `run`, `monthly_usage`,
session/shared-scan execution, and especially the sequential mode's DDL/DML
script (creates/truncates/inserts into a persistent cumulative table) have not
been exercised against live GA4 export data. That's what this draft is waiting
on before it's ready to merge.

## Scope notes

- `foe` pinned to the commit that added `foe/data` (`ffae166`) rather than
  floating on `@main` -- `first-order-engine` has no versioned releases yet.
- OAuth (`get_auth_url`/`exchange_code_for_credentials`) and the CSV/Sheets
  export helpers are **not** touched -- no `foe.data` equivalent for the latter,
  and swapping the login flow has a bigger blast radius than this pass is
  scoped for.
- No kill switch beyond uninstalling `foe` -- `USING_FOE_BACKEND` is decided
  once at import time. Worth adding a `st.secrets` override before this sees
  real traffic if we want to force native-only without a redeploy.
